### PR TITLE
Feature/server 2 server app client

### DIFF
--- a/cicd/backend/pipeline/build_lists_buildspec.yaml
+++ b/cicd/backend/pipeline/build_lists_buildspec.yaml
@@ -15,6 +15,16 @@ phases:
     commands:
       #- echo Installing dependencies...
 
+  pre_build:
+    commands:
+      - echo getting app clientID and secret
+      - aws cognito-idp describe-user-pool-client --user-pool-id $USER_POOL_ID --client-id $SERVICE_APP_CLIENT_ID --region $AWS_REGION > app_client.json
+      - export OIDC_CLIENT_ID=$(jq -r '.UserPoolClient.ClientId' app_client.json)
+      - echo OIDC_CLIENT_ID=$OIDC_CLIENT_ID
+      - export OIDC_CLIENT_SECRET=$(jq -r '.UserPoolClient.ClientSecret' app_client.json)
+      - echo OIDC_CLIENT_SECRET=$OIDC_CLIENT_SECRET
+
+
   build:
     commands:
       - echo Build started on $(date)

--- a/cicd/backend/pipeline/build_lists_buildspec.yaml
+++ b/cicd/backend/pipeline/build_lists_buildspec.yaml
@@ -30,7 +30,7 @@ phases:
       - sed -i "s/webservice.client-id=.*$/webservice.client-id=$OIDC_CLIENT_ID/g" lists-service/src/main/docker/application.properties
       - sed -i "s/webservice.client-secret=.*$/webservice.client-secret=$OIDC_CLIENT_SECRET/g" lists-service/src/main/docker/application.properties
 
-      - sed -i "s/security.jwt.clientId=.*$/security.jwt.clientId=$APP_CLIENT_ID/g" lists-service/config/list-service-config.properties
+      - sed -i "s/security.jwt.clientId=.*$/security.jwt.clientId=$APP_CLIENT_ID/g" lists-service/config/lists-service-config.properties
 
   build:
     commands:

--- a/cicd/backend/pipeline/build_lists_buildspec.yaml
+++ b/cicd/backend/pipeline/build_lists_buildspec.yaml
@@ -26,11 +26,11 @@ phases:
       - echo injecting app client details into the configs
       - sed -i "s/webservice.client-id=.*$/webservice.client-id=$OIDC_CLIENT_ID/g" lists-service/src/main/resources/application.properties
       - sed -i "s/webservice.client-secret=.*$/webservice.client-secret=$OIDC_CLIENT_SECRET/g" lists-service/src/main/resources/application.properties
-      - cat lists-service/src/main/resources/application.properties
 
       - sed -i "s/webservice.client-id=.*$/webservice.client-id=$OIDC_CLIENT_ID/g" lists-service/src/main/docker/application.properties
       - sed -i "s/webservice.client-secret=.*$/webservice.client-secret=$OIDC_CLIENT_SECRET/g" lists-service/src/main/docker/application.properties
-      - cat lists-service/src/main/docker/application.properties
+
+      - sed -i "s/security.jwt.clientId=.*$/security.jwt.clientId=$APP_CLIENT_ID/g" lists-service/config/list-service-config.properties
 
   build:
     commands:

--- a/cicd/backend/pipeline/build_lists_buildspec.yaml
+++ b/cicd/backend/pipeline/build_lists_buildspec.yaml
@@ -22,8 +22,15 @@ phases:
       - export OIDC_CLIENT_ID=$(jq -r '.UserPoolClient.ClientId' app_client.json)
       - echo OIDC_CLIENT_ID=$OIDC_CLIENT_ID
       - export OIDC_CLIENT_SECRET=$(jq -r '.UserPoolClient.ClientSecret' app_client.json)
-      - echo OIDC_CLIENT_SECRET=$OIDC_CLIENT_SECRET
+      - echo OIDC_CLIENT_SECRET=${OIDC_CLIENT_SECRET:0:3}************
+      - echo injecting app client details into the configs
+      - sed -i "s/webservice.client-id=.*$/webservice.client-id=$OIDC_CLIENT_ID/g" lists-service/src/main/resources/application.properties
+      - sed -i "s/webservice.client-secret=.*$/webservice.client-secret=$OIDC_CLIENT_SECRET/g" lists-service/src/main/resources/application.properties
+      - cat lists-service/src/main/resources/application.properties
 
+      - sed -i "s/webservice.client-id=.*$/webservice.client-id=$OIDC_CLIENT_ID/g" lists-service/src/main/docker/application.properties
+      - sed -i "s/webservice.client-secret=.*$/webservice.client-secret=$OIDC_CLIENT_SECRET/g" lists-service/src/main/docker/application.properties
+      - cat lists-service/src/main/docker/application.properties
 
   build:
     commands:

--- a/cicd/backend/pipeline/deploy_lists_buildspec.yaml
+++ b/cicd/backend/pipeline/deploy_lists_buildspec.yaml
@@ -19,7 +19,7 @@ phases:
       - chmod 700 get_helm.sh
       - ./get_helm.sh
 
-  pre-build:
+  pre_build:
     commands:
       - echo getting app clientID and secret
       - aws cognito-idp describe-user-pool-client --user-pool-id $USER_POOL_ID --client-id $SERVICE_APP_CLIENT_ID --region $AWS_REGION > app_client.json

--- a/cicd/backend/pipeline/deploy_lists_buildspec.yaml
+++ b/cicd/backend/pipeline/deploy_lists_buildspec.yaml
@@ -9,8 +9,6 @@ env:
     JAVA_TOOL_OPTIONS: -Dhttps.protocols=TLSv1.2
   secrets-manager:
     MONGODB_PASSWORD: $LISTS_SECRET_NAME:db-password
-    WEBSERVICE_CLIENT_ID: $LISTS_SECRET_NAME:webservice-client-id
-    WEBSERVICE_CLIENT_SECRET: $LISTS_SECRET_NAME:webservice-client-secret
 
 phases:
 
@@ -20,6 +18,15 @@ phases:
       - curl -fsSL -o get_helm.sh https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3
       - chmod 700 get_helm.sh
       - ./get_helm.sh
+
+  pre-build:
+    commands:
+      - echo getting app clientID and secret
+      - aws cognito-idp describe-user-pool-client --user-pool-id $USER_POOL_ID --client-id $SERVICE_APP_CLIENT_ID --region $AWS_REGION > app_client.json
+      - export WEBSERVICE_CLIENT_ID=$(jq -r '.UserPoolClient.ClientId' app_client.json)
+      - echo WEBSERVICE_CLIENT_ID=$WEBSERVICE_CLIENT_ID
+      - export WEBSERVICE_CLIENT_SECRET=$(jq -r '.UserPoolClient.ClientSecret' app_client.json)
+      - echo WEBSERVICE_CLIENT_SECRET=${WEBSERVICE_CLIENT_SECRET:0:3}************
 
   build:
     commands:

--- a/cicd/backend/pipeline/pipeline.yaml
+++ b/cicd/backend/pipeline/pipeline.yaml
@@ -346,9 +346,11 @@ Resources:
                       { "name":"MONGODB_USERNAME", "value":"${MongoDbUsername}" },
                       { "name":"NAMEMATCHING_BASE_URL", "value":"#{ExportConfigNS.NAMEMATCHING_BASE_URL}" },
                       { "name":"OIDC_CLIENT_ID", "value":"${AppClientId}" },
+                      { "name":"SERVICE_APP_CLIENT_ID", "value":"${ServiceAppClientId}" },
                       { "name":"OIDC_DISCOVERY_URI", "value":"${OidcDiscoveryUrl}" },
                       { "name":"SUB_DOMAIN", "value":"#{ExportConfigNS.SUB_DOMAIN}" },
-                      { "name":"USERDETAILS_BASE_URL", "value":"#{ExportConfigNS.USERDETAILS_BASE_URL}" }
+                      { "name":"USERDETAILS_BASE_URL", "value":"#{ExportConfigNS.USERDETAILS_BASE_URL}" },
+                      { "name":"USER_POOL_ID", "value":"${UserPoolId}" }
                     ]
                   - AppClientId:
                       Fn::ImportValue:
@@ -371,6 +373,12 @@ Resources:
                           - UserPoolId:
                               Fn::ImportValue:
                                 Fn::Sub: "${pCognitoStackName}-UserPoolId"
+                    ServiceAppClientId:
+                      Fn::ImportValue:
+                        Fn::Sub: "${pBaseStackName}-ServiceAppClientId"
+                    UserPoolId:
+                      Fn::ImportValue:
+                        Fn::Sub: "${pCognitoStackName}-UserPoolId"
 
             InputArtifacts:
               - Name: SourceArtifact

--- a/cicd/backend/pipeline/pipeline.yaml
+++ b/cicd/backend/pipeline/pipeline.yaml
@@ -295,6 +295,7 @@ Resources:
                   - |
                     [
                       { "name":"ALA_SECRETS_NAME", "value":"#{ExportConfigNS.ALA_SECRETS_NAME}" },
+                      { "name":"APP_CLIENT_ID", "value":"${AppClientId}" },
                       { "name":"AWS_ACCOUNT_ID", "value":"${AWS::AccountId}" },
                       { "name":"CLEAN_BRANCH", "value":"${pCleanBranch}" },
                       { "name":"DOCKER_USERNAME", "value":"#{ExportConfigNS.DOCKER_USERNAME}" },
@@ -305,7 +306,10 @@ Resources:
                       { "name":"SERVICE_APP_CLIENT_ID", "value":"${ServiceAppClientId}" },
                       { "name":"USER_POOL_ID", "value":"${UserPoolId}" }
                     ]
-                  - ServiceAppClientId:
+                  - AppClientId:
+                      Fn::ImportValue:
+                        Fn::Sub: "${pBaseStackName}-AppClientId"
+                    ServiceAppClientId:
                       Fn::ImportValue:
                         Fn::Sub: "${pBaseStackName}-ServiceAppClientId"
                     UserPoolId:

--- a/cicd/backend/pipeline/pipeline.yaml
+++ b/cicd/backend/pipeline/pipeline.yaml
@@ -280,7 +280,7 @@ Resources:
             OutputArtifacts: [ ]
             RunOrder: 2
 
-      - Name: Deploy_Helm_Chart
+      - Name: BuildLists
         Actions:
           - Name: BuildLists
             ActionTypeId:
@@ -290,17 +290,27 @@ Resources:
               Provider: CodeBuild
             Configuration:
               ProjectName: !Ref BuildLists
-              EnvironmentVariables: !Sub |
-                [
-                  { "name":"ALA_SECRETS_NAME", "value":"#{ExportConfigNS.ALA_SECRETS_NAME}" },
-                  { "name":"AWS_ACCOUNT_ID", "value":"${AWS::AccountId}" },
-                  { "name":"CLEAN_BRANCH", "value":"${pCleanBranch}" },
-                  { "name":"DOCKER_USERNAME", "value":"#{ExportConfigNS.DOCKER_USERNAME}" },
-                  { "name":"ECR_REPO", "value":"#{BuildCloudFormationOutNS.ListsRepositoryUri}" },
-                  { "name":"ENVIRONMENT", "value":"${pEnvironment}" },
-                  { "name":"IMAGE_NAME", "value":"#{ExportConfigNS.IMAGE_NAME}" },
-                  { "name":"IMAGE_TAG", "value":"#{ExportConfigNS.IMAGE_TAG}" }
-                ]
+              EnvironmentVariables:
+                Fn::Sub:
+                  - |
+                    [
+                      { "name":"ALA_SECRETS_NAME", "value":"#{ExportConfigNS.ALA_SECRETS_NAME}" },
+                      { "name":"AWS_ACCOUNT_ID", "value":"${AWS::AccountId}" },
+                      { "name":"CLEAN_BRANCH", "value":"${pCleanBranch}" },
+                      { "name":"DOCKER_USERNAME", "value":"#{ExportConfigNS.DOCKER_USERNAME}" },
+                      { "name":"ECR_REPO", "value":"#{BuildCloudFormationOutNS.ListsRepositoryUri}" },
+                      { "name":"ENVIRONMENT", "value":"${pEnvironment}" },
+                      { "name":"IMAGE_NAME", "value":"#{ExportConfigNS.IMAGE_NAME}" },
+                      { "name":"IMAGE_TAG", "value":"#{ExportConfigNS.IMAGE_TAG}" },
+                      { "name":"SERVICE_APP_CLIENT_ID", "value":"${ServiceAppClientId}" },
+                      { "name":"USER_POOL_ID", "value":"${UserPoolId}" }
+                    ]
+                  - ServiceAppClientId:
+                      Fn::ImportValue:
+                        Fn::Sub: "${pBaseStackName}-ServiceAppClientId"
+                  - UserPoolId:
+                      Fn::ImportValue:
+                        Fn::Sub: "${pCognitoStackName}-UserPoolId"
             InputArtifacts:
               - Name: 'SourceArtifact'
             RunOrder: 1

--- a/cicd/backend/pipeline/pipeline.yaml
+++ b/cicd/backend/pipeline/pipeline.yaml
@@ -308,7 +308,7 @@ Resources:
                   - ServiceAppClientId:
                       Fn::ImportValue:
                         Fn::Sub: "${pBaseStackName}-ServiceAppClientId"
-                  - UserPoolId:
+                    UserPoolId:
                       Fn::ImportValue:
                         Fn::Sub: "${pCognitoStackName}-UserPoolId"
             InputArtifacts:

--- a/cicd/base/app/base.yaml
+++ b/cicd/base/app/base.yaml
@@ -17,7 +17,10 @@ Parameters:
     Description: The name of the Cognito stack
   pAppClientHost:
     Type: String
-    Description: The host for the app client
+    Description: The host for the app client for the frontend
+  pAppClientServiceHost:
+    Type: String
+    Description: The host for the app client for the service
 
 Conditions:
 
@@ -64,7 +67,7 @@ Resources:
         - ALLOW_CUSTOM_AUTH
         - ALLOW_REFRESH_TOKEN_AUTH
         - ALLOW_USER_SRP_AUTH
-      GenerateSecret: True
+      GenerateSecret: False
       IdTokenValidity: 60
       LogoutURLs: 
         - !Sub ${pAppClientHost}
@@ -85,10 +88,67 @@ Resources:
         Fn::ImportValue:
             !Sub ${pCognitoStackName}-UserPoolId
 
+  ListsServiceAppClient:
+    Type: AWS::Cognito::UserPoolClient
+    Properties:
+      AccessTokenValidity: 60
+      AllowedOAuthFlows: 
+        - code
+      AllowedOAuthFlowsUserPoolClient: True
+      AllowedOAuthScopes: 
+        - ala/attrs
+        - ala/roles
+        - email
+        - openid
+        - profile
+        - users/read
+      AuthSessionValidity: 3
+      CallbackURLs: 
+        - !Sub ${pAppClientServiceHost}
+        - !Sub ${pAppClientServiceHost}/
+        - !Sub ${pAppClientServiceHost}/callback?client_name=OidcClient
+        - !Sub ${pAppClientServiceHost}/oauth2-redirect.html
+      ClientName: !Sub
+          - species-lists-${ResourceName}
+          - ResourceName: !If [ IsDev, !Ref pCleanBranch, !Ref pEnvironment ]
+      DefaultRedirectURI: !Sub ${pAppClientServiceHost}/callback?client_name=OidcClient
+      EnablePropagateAdditionalUserContextData: False
+      EnableTokenRevocation: True
+      ExplicitAuthFlows:
+        - ALLOW_ADMIN_USER_PASSWORD_AUTH
+        - ALLOW_CUSTOM_AUTH
+        - ALLOW_REFRESH_TOKEN_AUTH
+        - ALLOW_USER_SRP_AUTH
+      GenerateSecret: True
+      IdTokenValidity: 60
+      LogoutURLs: 
+        - !Sub ${pAppClientServiceHost}
+        - !Sub ${pAppClientServiceHost}/
+      PreventUserExistenceErrors: ENABLED
+      RefreshTokenValidity: 30
+      SupportedIdentityProviders:
+        - COGNITO
+        - Facebook
+        - Google
+        - AAF
+        - SignInWithApple
+      TokenValidityUnits:
+        AccessToken: minutes
+        IdToken: minutes
+        RefreshToken: days
+      UserPoolId: 
+        Fn::ImportValue:
+            !Sub ${pCognitoStackName}-UserPoolId
+
 Outputs:
 
   AppClientId:
-    Description: The app client for the lists service
+    Description: The app client for the lists frontend
     Value: !Ref ListsAppClient
     Export:
       Name: !Sub ${AWS::StackName}-AppClientId
+  ServiceAppClientId:
+    Description: The app client for the lists backend service
+    Value: !Ref ListsServiceAppClient
+    Export:
+      Name: !Sub ${AWS::StackName}-ServiceAppClientId

--- a/cicd/base/app/base_template_config.j2
+++ b/cicd/base/app/base_template_config.j2
@@ -1,10 +1,11 @@
 {
   "Parameters" : {
+    "pAppClientHost"        : "{{ app_client_host }}",
+    "pAppClientServiceHost" : "{{ app_client_service_host }}",
     "pBuild"                : "{{ codebuild_build_number }}",
     "pCleanBranch"          : "{{ clean_branch }}",
-    "pEnvironment"          : "{{ environment }}",
     "pCognitoStackName"     : "{{ cognito_stack_name }}",
-    "pAppClientHost"        : "{{ app_client_host }}"
+    "pEnvironment"          : "{{ environment }}"
   },
   "Tags" : {
     "product"     : "{{ product_name }}",

--- a/cicd/base/config.ini
+++ b/cicd/base/config.ini
@@ -7,6 +7,7 @@ SLACK_DEPLOY_NOTIFICATION = true
 SLACK_ALERT_CHANNEL = zabbix-alerts
 
 APP_CLIENT_HOST = https://${LISTS_UI_HOST}
+APP_CLIENT_SERVICE_HOST = https://${LISTS_SERVICE_HOST}
 
 [development]
 # code pipeline

--- a/cicd/frontend/pipeline/npm_build_buildspec.yaml
+++ b/cicd/frontend/pipeline/npm_build_buildspec.yaml
@@ -13,6 +13,9 @@ phases:
     commands:
       - cp lists-ui/vite.properties lists-ui/.env
       - cd lists-ui
+      - echo injecting app client config
+      - sed -i "s/VITE_AUTH_CLIENT_ID=.*$/VITE_AUTH_CLIENT_ID=$VITE_AUTH_CLIENT_ID/g" lists-ui/config/.env.$ENVIRONMENT
+      - cat lists-ui/config/.env.$ENVIRONMENT
   pre_build:
     commands:
       - echo running npm install...

--- a/cicd/frontend/pipeline/npm_build_buildspec.yaml
+++ b/cicd/frontend/pipeline/npm_build_buildspec.yaml
@@ -12,10 +12,10 @@ phases:
       nodejs: $NODE_VERSION
     commands:
       - cp lists-ui/vite.properties lists-ui/.env
-      - cd lists-ui
       - echo injecting app client config
       - sed -i "s/VITE_AUTH_CLIENT_ID=.*$/VITE_AUTH_CLIENT_ID=$VITE_AUTH_CLIENT_ID/g" lists-ui/config/.env.$ENVIRONMENT
       - cat lists-ui/config/.env.$ENVIRONMENT
+      - cd lists-ui
   pre_build:
     commands:
       - echo running npm install...


### PR DESCRIPTION
- Add the server to server app client
- Dont generate a secrets on the ui app client
- inject the app client id and secret into the various configs

For discussion
- I think it would be better to save the app client ids and secrets in secrets manager right after they are created, then later components can access them directly without scripting mess. This would mean the secret resource creation would need to be moved from the database back to the base component
- Using CloudFormation exports means some components cant be changed if they are in use, for example if an app client secret needs to be rotated then it cant be directly changed. This is good as it will prevent accidental deletion or change but it means things like this will have to be done in a 3 step process
  - first create a branch new app client
  - update all the components to use the new app client
  - delete the original app client
 Doing it this way mean there will be not service interruption during updates
