### PR TITLE
App client changes

### DIFF
--- a/cicd/backend/pipeline/deploy_lists_buildspec.yaml
+++ b/cicd/backend/pipeline/deploy_lists_buildspec.yaml
@@ -40,6 +40,8 @@ phases:
         webservice:
           clientId: $WEBSERVICE_CLIENT_ID
           clientSecret: $WEBSERVICE_CLIENT_SECRET
+        app:
+          url: $SUB_DOMAIN.$HOSTED_ZONE
         bie:
           baseUrl: $BIE_BASE_URL
         biocache:

--- a/cicd/backend/pipeline/pipeline.yaml
+++ b/cicd/backend/pipeline/pipeline.yaml
@@ -308,15 +308,15 @@ Resources:
                     ]
                   - AppClientId:
                       Fn::ImportValue:
-                        Fn::Sub: "${pBaseStackName}-AppClientId"
+                        Fn::Sub: ${pBaseStackName}-AppClientIdB
                     ServiceAppClientId:
                       Fn::ImportValue:
-                        Fn::Sub: "${pBaseStackName}-ServiceAppClientId"
+                        Fn::Sub: ${pBaseStackName}-ServiceAppClientId
                     UserPoolId:
                       Fn::ImportValue:
-                        Fn::Sub: "${pCognitoStackName}-UserPoolId"
+                        Fn::Sub: ${pCognitoStackName}-UserPoolId
             InputArtifacts:
-              - Name: 'SourceArtifact'
+              - Name: SourceArtifact
             RunOrder: 1
 
           - Name: DeployLists
@@ -354,7 +354,7 @@ Resources:
                     ]
                   - AppClientId:
                       Fn::ImportValue:
-                        Fn::Sub: "${pBaseStackName}-AppClientId"
+                        Fn::Sub: "${pBaseStackName}-AppClientIdB"
                     EksClusterName:
                       Fn::ImportValue:
                         Fn::Sub: "${pRegolithStackName}-ClusterName"

--- a/cicd/backend/pipeline/pipeline.yaml
+++ b/cicd/backend/pipeline/pipeline.yaml
@@ -336,9 +336,9 @@ Resources:
                       { "name":"SUB_DOMAIN", "value":"#{ExportConfigNS.SUB_DOMAIN}" },
                       { "name":"USERDETAILS_BASE_URL", "value":"#{ExportConfigNS.USERDETAILS_BASE_URL}" }
                     ]
-                  - AppClientId: dummy
-                      #Fn::ImportValue:
-                      #  Fn::Sub: "${pBaseStackName}-AppClientId"
+                  - AppClientId:
+                      Fn::ImportValue:
+                        Fn::Sub: "${pBaseStackName}-AppClientId"
                     EksClusterName:
                       Fn::ImportValue:
                         Fn::Sub: "${pRegolithStackName}-ClusterName"

--- a/cicd/backend/pipeline/pipeline.yaml
+++ b/cicd/backend/pipeline/pipeline.yaml
@@ -336,9 +336,9 @@ Resources:
                       { "name":"SUB_DOMAIN", "value":"#{ExportConfigNS.SUB_DOMAIN}" },
                       { "name":"USERDETAILS_BASE_URL", "value":"#{ExportConfigNS.USERDETAILS_BASE_URL}" }
                     ]
-                  - AppClientId:
-                      Fn::ImportValue:
-                        Fn::Sub: "${pBaseStackName}-AppClientId"
+                  - AppClientId: dummy
+                      #Fn::ImportValue:
+                      #  Fn::Sub: "${pBaseStackName}-AppClientId"
                     EksClusterName:
                       Fn::ImportValue:
                         Fn::Sub: "${pRegolithStackName}-ClusterName"

--- a/cicd/base/app/base.yaml
+++ b/cicd/base/app/base.yaml
@@ -35,6 +35,110 @@ Conditions:
 
 Resources:
 
+  ListsAppClientB:
+    Type: AWS::Cognito::UserPoolClient
+    Properties:
+      AccessTokenValidity: 60
+      AllowedOAuthFlows: 
+        - code
+      AllowedOAuthFlowsUserPoolClient: True
+      AllowedOAuthScopes: 
+        - ala/attrs
+        - ala/internal
+        - ala/roles
+        - email
+        - openid
+        - profile
+        - users/read
+      AuthSessionValidity: 3
+      CallbackURLs: 
+        - !Sub ${pAppClientHost}
+        - !Sub ${pAppClientHost}/
+        - !Sub ${pAppClientHost}/callback?client_name=OidcClient
+        - !Sub ${pAppClientHost}/oauth2-redirect.html
+      ClientName: !Sub
+          - species-lists-${ResourceName}
+          - ResourceName: !If [ IsDev, !Ref pCleanBranch, !Ref pEnvironment ]
+      DefaultRedirectURI: !Sub ${pAppClientHost}
+      EnablePropagateAdditionalUserContextData: False
+      EnableTokenRevocation: True
+      ExplicitAuthFlows:
+        - ALLOW_ADMIN_USER_PASSWORD_AUTH
+        - ALLOW_CUSTOM_AUTH
+        - ALLOW_REFRESH_TOKEN_AUTH
+        - ALLOW_USER_SRP_AUTH
+      GenerateSecret: False
+      IdTokenValidity: 60
+      LogoutURLs: 
+        - !Sub ${pAppClientHost}
+        - !Sub ${pAppClientHost}/
+      PreventUserExistenceErrors: ENABLED
+      RefreshTokenValidity: 30
+      SupportedIdentityProviders:
+        - COGNITO
+        - Facebook
+        - Google
+        - AAF
+        - SignInWithApple
+      TokenValidityUnits:
+        AccessToken: minutes
+        IdToken: minutes
+        RefreshToken: days
+      UserPoolId: 
+        Fn::ImportValue:
+            !Sub ${pCognitoStackName}-UserPoolId
+
+  ListsServiceAppClientB:
+    Type: AWS::Cognito::UserPoolClient
+    Properties:
+      AccessTokenValidity: 60
+      AllowedOAuthFlows: 
+        - code
+      AllowedOAuthFlowsUserPoolClient: True
+      AllowedOAuthScopes: 
+        - ala/attrs
+        - ala/roles
+        - email
+        - openid
+        - profile
+        - users/read
+      AuthSessionValidity: 3
+      CallbackURLs: 
+        - !Sub ${pAppClientServiceHost}
+        - !Sub ${pAppClientServiceHost}/
+        - !Sub ${pAppClientServiceHost}/callback?client_name=OidcClient
+        - !Sub ${pAppClientServiceHost}/oauth2-redirect.html
+      ClientName: !Sub
+          - species-lists-${ResourceName}
+          - ResourceName: !If [ IsDev, !Ref pCleanBranch, !Ref pEnvironment ]
+      DefaultRedirectURI: !Sub ${pAppClientServiceHost}/callback?client_name=OidcClient
+      EnablePropagateAdditionalUserContextData: False
+      EnableTokenRevocation: True
+      ExplicitAuthFlows:
+        - ALLOW_ADMIN_USER_PASSWORD_AUTH
+        - ALLOW_CUSTOM_AUTH
+        - ALLOW_REFRESH_TOKEN_AUTH
+        - ALLOW_USER_SRP_AUTH
+      GenerateSecret: True
+      IdTokenValidity: 60
+      LogoutURLs: 
+        - !Sub ${pAppClientServiceHost}
+        - !Sub ${pAppClientServiceHost}/
+      PreventUserExistenceErrors: ENABLED
+      RefreshTokenValidity: 30
+      SupportedIdentityProviders:
+        - COGNITO
+        - Facebook
+        - Google
+        - AAF
+        - SignInWithApple
+      TokenValidityUnits:
+        AccessToken: minutes
+        IdToken: minutes
+        RefreshToken: days
+      UserPoolId: 
+        Fn::ImportValue:
+            !Sub ${pCognitoStackName}-UserPoolId
   ListsAppClient:
     Type: AWS::Cognito::UserPoolClient
     Properties:
@@ -152,3 +256,13 @@ Outputs:
     Value: !Ref ListsServiceAppClient
     Export:
       Name: !Sub ${AWS::StackName}-ServiceAppClientId
+  AppClientIdB:
+    Description: The app client for the lists frontend
+    Value: !Ref ListsAppClientB
+    Export:
+      Name: !Sub ${AWS::StackName}-AppClientIdB
+  ServiceAppClientIdB:
+    Description: The app client for the lists backend service
+    Value: !Ref ListsServiceAppClientB
+    Export:
+      Name: !Sub ${AWS::StackName}-ServiceAppClientIdB

--- a/cicd/base/app/base.yaml
+++ b/cicd/base/app/base.yaml
@@ -40,11 +40,13 @@ Resources:
         - code
       AllowedOAuthFlowsUserPoolClient: True
       AllowedOAuthScopes: 
+        - ala/attrs
+        - ala/internal
+        - ala/roles
+        - email
         - openid
         - profile
-        - email
-        - ala/roles
-        - ala/attrs
+        - users/read
       AuthSessionValidity: 3
       CallbackURLs: 
         - !Sub ${pAppClientHost}
@@ -59,7 +61,7 @@ Resources:
         - ALLOW_CUSTOM_AUTH
         - ALLOW_REFRESH_TOKEN_AUTH
         - ALLOW_USER_SRP_AUTH
-      GenerateSecret: False
+      GenerateSecret: True
       IdTokenValidity: 60
       LogoutURLs: 
         - !Sub ${pAppClientHost}

--- a/cicd/base/app/base.yaml
+++ b/cicd/base/app/base.yaml
@@ -50,6 +50,9 @@ Resources:
       AuthSessionValidity: 3
       CallbackURLs: 
         - !Sub ${pAppClientHost}
+        - !Sub ${pAppClientHost}/
+        - !Sub ${pAppClientHost}/callback?client_name=OidcClient
+        - !Sub ${pAppClientHost}/oauth2-redirect.html
       ClientName: !Sub
           - species-lists-${ResourceName}
           - ResourceName: !If [ IsDev, !Ref pCleanBranch, !Ref pEnvironment ]
@@ -65,6 +68,7 @@ Resources:
       IdTokenValidity: 60
       LogoutURLs: 
         - !Sub ${pAppClientHost}
+        - !Sub ${pAppClientHost}/
       PreventUserExistenceErrors: ENABLED
       RefreshTokenValidity: 30
       SupportedIdentityProviders:

--- a/cicd/base/app/base.yaml
+++ b/cicd/base/app/base.yaml
@@ -139,6 +139,7 @@ Resources:
       UserPoolId: 
         Fn::ImportValue:
             !Sub ${pCognitoStackName}-UserPoolId
+
   ListsAppClient:
     Type: AWS::Cognito::UserPoolClient
     Properties:
@@ -171,7 +172,7 @@ Resources:
         - ALLOW_CUSTOM_AUTH
         - ALLOW_REFRESH_TOKEN_AUTH
         - ALLOW_USER_SRP_AUTH
-      GenerateSecret: False
+      GenerateSecret: True
       IdTokenValidity: 60
       LogoutURLs: 
         - !Sub ${pAppClientHost}

--- a/cicd/branch_2_env.py
+++ b/cicd/branch_2_env.py
@@ -21,6 +21,9 @@ if re.search('^main$|^master$', args.branch) and args.env == 'prod':
 elif re.search('^main$|^master$', args.branch):
   #print(f"Branch {args.branch} matched release")
   print('staging')
+elif re.search('^testing$', args.branch):
+  #print(f"Branch {args.branch} matched release")
+  print('testing')
 else:
   #print(f"Branch {args.branch} didnt match")
   print('development')

--- a/cicd/frontend/pipeline/pipeline.yaml
+++ b/cicd/frontend/pipeline/pipeline.yaml
@@ -317,13 +317,13 @@ Resources:
                       ]
                     - OidcClientId:
                         Fn::ImportValue:
-                          Fn::Sub: "${pBaseStackName}-AppClientId"
+                          Fn::Sub: ${pBaseStackName}-AppClientIdB
                       OidcDiscoveryUrl:
                         Fn::Sub:
                           - "https://cognito-idp.${AWS::Region}.amazonaws.com/${UserPoolId}"
                           - UserPoolId:
                               Fn::ImportValue:
-                                Fn::Sub: "${pCognitoStackName}-UserPoolId"
+                                Fn::Sub: ${pCognitoStackName}-UserPoolId
 
               Namespace: BuildListsNS
               InputArtifacts:

--- a/cicd/frontend/pipeline/pipeline.yaml
+++ b/cicd/frontend/pipeline/pipeline.yaml
@@ -315,9 +315,9 @@ Resources:
                         { "name":"VITE_AUTH_END_SESSION_URI", "value":"#{ExportConfigNS.VITE_AUTH_END_SESSION_URI}"},
                         { "name":"VITE_AUTH_REDIRECT_URI", "value":"#{ExportConfigNS.VITE_AUTH_REDIRECT_URI}"}
                       ]
-                    - OidcClientId: dummy
-                       # Fn::ImportValue:
-                       #   Fn::Sub: "${pBaseStackName}-AppClientId"
+                    - OidcClientId:
+                        Fn::ImportValue:
+                          Fn::Sub: "${pBaseStackName}-AppClientId"
                       OidcDiscoveryUrl:
                         Fn::Sub:
                           - "https://cognito-idp.${AWS::Region}.amazonaws.com/${UserPoolId}"

--- a/cicd/frontend/pipeline/pipeline.yaml
+++ b/cicd/frontend/pipeline/pipeline.yaml
@@ -315,9 +315,9 @@ Resources:
                         { "name":"VITE_AUTH_END_SESSION_URI", "value":"#{ExportConfigNS.VITE_AUTH_END_SESSION_URI}"},
                         { "name":"VITE_AUTH_REDIRECT_URI", "value":"#{ExportConfigNS.VITE_AUTH_REDIRECT_URI}"}
                       ]
-                    - OidcClientId:
-                        Fn::ImportValue:
-                          Fn::Sub: "${pBaseStackName}-AppClientId"
+                    - OidcClientId: dummy
+                       # Fn::ImportValue:
+                       #   Fn::Sub: "${pBaseStackName}-AppClientId"
                       OidcDiscoveryUrl:
                         Fn::Sub:
                           - "https://cognito-idp.${AWS::Region}.amazonaws.com/${UserPoolId}"

--- a/lists-service/helm/config/lists-service-config.properties
+++ b/lists-service/helm/config/lists-service-config.properties
@@ -1,5 +1,7 @@
 app.name=species-lists
 app.description=${app.name} is a Spring Boot application
+app.version={{ .Values.app.url }}
+app.url={{ .Values.app.url }}
 spring.graphql.graphiql.enabled=true
 spring.graphql.graphiql.path=/graphiql
 elastic.host=elasticsearch:9200
@@ -36,6 +38,11 @@ security.jwt.discovery-uri=${oidc.discoveryUri}
 security.jwt.clientId=${oidc.clientId}
 security.apikey.enabled=false
 
+webservice.read.timeout=600000
+webservice.connect.timeout=600000
+webservice.jwt=true
+webservice.jwt-scopes=users/read ala/attrs ala/internal
+
 # admin role and admin scope
 security.admin.role=ROLE_ADMIN,ala/internal
 
@@ -55,3 +62,4 @@ mongodb.database={{ .Values.mongodb.database }}
 
 oidc.enabled={{ .Values.oidc.enabled }}
 oidc.discoveryUri={{ .Values.oidc.discoveryUri }}
+oidc.clientId={{ .Values.oidc.clientId }}

--- a/lists-service/helm/values.yaml
+++ b/lists-service/helm/values.yaml
@@ -71,6 +71,10 @@ tolerations: []
 
 affinity: {}
 
+app:
+  version: "1.0.0"
+  url: ""
+
 mongodb:
   username: ""
   password: ""

--- a/lists-service/src/main/java/au/org/ala/listsapi/WebConfig.java
+++ b/lists-service/src/main/java/au/org/ala/listsapi/WebConfig.java
@@ -11,6 +11,11 @@ public class WebConfig implements WebMvcConfigurer {
 
   @Override
   public void addCorsMappings(CorsRegistry registry) {
-    registry.addMapping("/**");
+    registry.addMapping("/**").
+        allowedOrigins("*").
+        allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS").
+        allowedHeaders("*").
+        allowCredentials(true).
+        maxAge(3600);
   }
 }

--- a/lists-ui/config/.env.development
+++ b/lists-ui/config/.env.development
@@ -20,7 +20,7 @@ VITE_AUTH_AUTHORITY=https://cognito-idp.ap-southeast-2.amazonaws.com/ap-southeas
 VITE_AUTH_CLIENT_ID=2e2gl2gbl5o6shjb8nqlr39e8k
 VITE_AUTH_REDIRECT_URI=https://lists.test.ala.org.au
 VITE_AUTH_END_SESSION_URI=https://auth-secure.auth.ap-southeast-2.amazoncognito.com/logout
-VITE_AUTH_SCOPE=openid profile email ala/attrs ala/roles
+VITE_AUTH_SCOPE=openid profile email ala/attrs ala/roles ala/internal users/read
 
 # ALA Endpoints
 VITE_ALA_BIE_SPECIES=https://bie.ala.org.au/species

--- a/lists-ui/config/.env.development
+++ b/lists-ui/config/.env.development
@@ -17,7 +17,7 @@ VITE_API_ADMIN_MIGRATE=/migrate
 
 # Authentication
 VITE_AUTH_AUTHORITY=https://cognito-idp.ap-southeast-2.amazonaws.com/ap-southeast-2_OOXU9GW39
-VITE_AUTH_CLIENT_ID=3u4obi49r09eu87lcravb1h95b
+VITE_AUTH_CLIENT_ID=2e2gl2gbl5o6shjb8nqlr39e8k
 VITE_AUTH_REDIRECT_URI=https://lists.test.ala.org.au
 VITE_AUTH_END_SESSION_URI=https://auth-secure.auth.ap-southeast-2.amazoncognito.com/logout
 VITE_AUTH_SCOPE=openid profile email ala/attrs ala/roles

--- a/lists-ui/config/.env.testing
+++ b/lists-ui/config/.env.testing
@@ -20,7 +20,7 @@ VITE_AUTH_AUTHORITY=https://cognito-idp.ap-southeast-2.amazonaws.com/ap-southeas
 VITE_AUTH_CLIENT_ID=46gj0tm07vt0pv8m8o21tmcl60
 VITE_AUTH_REDIRECT_URI=https://lists.test.ala.org.au
 VITE_AUTH_END_SESSION_URI=https://auth-secure.auth.ap-southeast-2.amazoncognito.com/logout
-VITE_AUTH_SCOPE=openid profile email ala/attrs ala/roles
+VITE_AUTH_SCOPE=openid profile email ala/attrs ala/roles ala/internal users/read
 
 # ALA Endpoints
 VITE_ALA_BIE_SPECIES=https://bie.ala.org.au/species

--- a/lists-ui/config/.env.testing
+++ b/lists-ui/config/.env.testing
@@ -1,6 +1,6 @@
 # Application API Endpoints
 VITE_API_BASEURL=https://lists-ws.test.ala.org.au
-VITE_API_GRAPHQL=/graphiql
+VITE_API_GRAPHQL=/graphql
 VITE_API_LIST_UPLOAD=/upload
 VITE_API_LIST_DOWNLOAD=/download
 VITE_API_LIST_INGEST=/ingest

--- a/lists-ui/config/.env.testing
+++ b/lists-ui/config/.env.testing
@@ -16,11 +16,11 @@ VITE_API_ADMIN_REMATCH=/rematch
 VITE_API_ADMIN_MIGRATE=/migrate
 
 # Authentication
-VITE_AUTH_AUTHORITY=ENTER-HERE
-VITE_AUTH_CLIENT_ID=ENTER-HERE
-VITE_AUTH_REDIRECT_URI=ENTER-HERE
-VITE_AUTH_END_SESSION_URI=ENTER-HERE
-VITE_AUTH_SCOPE=ENTER-HERE
+VITE_AUTH_AUTHORITY=https://cognito-idp.ap-southeast-2.amazonaws.com/ap-southeast-2_OOXU9GW39
+VITE_AUTH_CLIENT_ID=46gj0tm07vt0pv8m8o21tmcl60
+VITE_AUTH_REDIRECT_URI=https://lists.test.ala.org.au
+VITE_AUTH_END_SESSION_URI=https://auth-secure.auth.ap-southeast-2.amazoncognito.com/logout
+VITE_AUTH_SCOPE=openid profile email ala/attrs ala/roles
 
 # ALA Endpoints
 VITE_ALA_BIE_SPECIES=https://bie.ala.org.au/species


### PR DESCRIPTION
- Add the server to server app client
- Don't generate a secrets on the ui app client
- inject the app client id and secret into the various configs
- Add [permissive CORS policy ](https://github.com/AtlasOfLivingAustralia/species-lists/pull/128/files#diff-92edf8aa4c3d4e882b31278c9e1fd8ee7a4fd30dc4bb95d13248f06c8f5971c1)
- Temporary app clients to allow changes to be made while the original ones are still being referenced as exports 