### PR TITLE
remove unsupported scopes

### DIFF
--- a/cicd/base/app/base.yaml
+++ b/cicd/base/app/base.yaml
@@ -98,7 +98,6 @@ Resources:
       AllowedOAuthScopes: 
         - ala/attrs
         - ala/roles
-        - openid
         - profile
         - users/read
       AuthSessionValidity: 3

--- a/cicd/base/app/base.yaml
+++ b/cicd/base/app/base.yaml
@@ -98,7 +98,6 @@ Resources:
       AllowedOAuthScopes: 
         - ala/attrs
         - ala/roles
-        - email
         - openid
         - profile
         - users/read

--- a/cicd/base/app/base.yaml
+++ b/cicd/base/app/base.yaml
@@ -98,7 +98,6 @@ Resources:
       AllowedOAuthScopes: 
         - ala/attrs
         - ala/roles
-        - profile
         - users/read
       AuthSessionValidity: 3
       CallbackURLs: 


### PR DESCRIPTION
These are not supported for client_credentials auth 