### PR TITLE
move secret to base component

### DIFF
--- a/cicd/backend/pipeline/pipeline.yaml
+++ b/cicd/backend/pipeline/pipeline.yaml
@@ -357,7 +357,7 @@ Resources:
                         Fn::Sub: "${pRegolithStackName}-FileSystemId"
                     ListSecretName:
                       Fn::ImportValue:
-                        Fn::Sub: "${pDatabaseStackName}-DocDbPasswordSecretName"
+                        Fn::Sub: "${pBaseStackName}-DocDbPasswordSecretName"
                     MongoDbHost:
                       Fn::ImportValue:
                         Fn::Sub: "${pDatabaseStackName}-DocDbClusterEndpoint"

--- a/cicd/base/app/base.yaml
+++ b/cicd/base/app/base.yaml
@@ -35,6 +35,14 @@ Conditions:
 
 Resources:
 
+  DocDbPasswordSecret:
+    Type: AWS::SecretsManager::Secret
+    Properties:
+      Name: !Sub 
+              - lists-${ResourceName}
+              - ResourceName: !If [ IsDev, !Ref pCleanBranch, !Ref pEnvironment ]
+      Description: !Sub Lists app ${pEnvironment} secrets
+
   ListsAppClient:
     Type: AWS::Cognito::UserPoolClient
     Properties:
@@ -145,6 +153,15 @@ Outputs:
     Value: !Ref ListsAppClient
     Export:
       Name: !Sub ${AWS::StackName}-AppClientId
+
+  DocDbPasswordSecretName:
+    Description: The Secrets name for lists 
+    Value: !Sub
+      - lists-${ResourceName}
+      - ResourceName: !If [ IsDev, !Ref pCleanBranch, !Ref pEnvironment ]
+    Export:
+      Name: !Sub ${AWS::StackName}-DocDbPasswordSecretName
+
   ServiceAppClientId:
     Description: The app client for the lists backend service
     Value: !Ref ListsServiceAppClient

--- a/cicd/database/app/database.yaml
+++ b/cicd/database/app/database.yaml
@@ -64,24 +64,6 @@ Conditions:
 
 Resources:
 
-  DocDbPasswordSecret:
-    Type: AWS::SecretsManager::Secret
-    Properties:
-      # if the name of the secret is changed make sure you change the value for the DocDbCluster.Properties.MasterUserPassword 
-      # and the  stack Output.DocDbPasswordSecretName
-      Name: !Sub 
-              - lists-${ResourceName}
-              - ResourceName: !If [ IsDev, !Ref pCleanBranch, !Ref pEnvironment ]
-      Description: !Sub Lists app ${pEnvironment} secrets
-      GenerateSecretString: 
-        GenerateStringKey: db-password
-        PasswordLength: 12
-        ExcludeCharacters: "/@\" \\+%:"
-        SecretStringTemplate: |
-                {
-                   "db-password" : ""
-                }
-
   DocDbSubnetGrp:
     Type: AWS::DocDB::DBSubnetGroup
     Properties:
@@ -137,7 +119,6 @@ Resources:
   DocDbCluster:
     Type: AWS::DocDB::DBCluster
     DependsOn: 
-      - DocDbPasswordSecret
       - DocDbClusterParameterGroup
       - DocDbSecurityGrp
       - DocDbSubnetGrp
@@ -187,20 +168,6 @@ Outputs:
     Value: !Ref pAdminUser
     Export: 
       Name: !Sub ${AWS::StackName}-DocDbUsername
-
-  DocDbPasswordSecret:
-    Description: The Secrets name for lists 
-    Value: !Ref DocDbPasswordSecret
-    Export:
-      Name: !Sub ${AWS::StackName}-DocDbPasswordSecret
-
-  DocDbPasswordSecretName:
-    Description: The Secrets name for lists 
-    Value: !Sub
-      - lists-${ResourceName}
-      - ResourceName: !If [ IsDev, !Ref pCleanBranch, !Ref pEnvironment ]
-    Export:
-      Name: !Sub ${AWS::StackName}-DocDbPasswordSecretName
 
   DocDbClusterEndpoint:
     Description: The endpoint of the DocumentDB cluster


### PR DESCRIPTION
Currently the product secret is created in the database component/stack and the database password is autogenerated on launch/update. This works but it means that whenever the database component/stack is launched the password is rotated and the app breaks until the backend can be re-launched.

This PR moves the creation of the secret to the base component, it also removes the autogeneration of the database password which now must be done manually. This means that the database password will never be rotated or overwritten from launching a stack. It can still be done but it's now a manual process that is done in the AWS console