### PR TITLE
move secret to base component

### DIFF
--- a/cicd/backend/pipeline/pipeline.yaml
+++ b/cicd/backend/pipeline/pipeline.yaml
@@ -355,9 +355,9 @@ Resources:
                     FileSystemId: 
                       Fn::ImportValue:
                         Fn::Sub: "${pRegolithStackName}-FileSystemId"
-                    ListSecretName: ala-lists-base-development
-                    #  Fn::ImportValue:
-                    #    Fn::Sub: "${pBaseStackName}-DocDbPasswordSecretName"
+                    ListSecretName:
+                      Fn::ImportValue:
+                        Fn::Sub: "${pBaseStackName}-DocDbPasswordSecretName"
                     MongoDbHost:
                       Fn::ImportValue:
                         Fn::Sub: "${pDatabaseStackName}-DocDbClusterEndpoint"

--- a/cicd/backend/pipeline/pipeline.yaml
+++ b/cicd/backend/pipeline/pipeline.yaml
@@ -352,12 +352,12 @@ Resources:
                     EksClusterName:
                       Fn::ImportValue:
                         Fn::Sub: "${pRegolithStackName}-ClusterName"
-                    FileSystemId:
+                    FileSystemId: 
                       Fn::ImportValue:
                         Fn::Sub: "${pRegolithStackName}-FileSystemId"
-                    ListSecretName:
-                      Fn::ImportValue:
-                        Fn::Sub: "${pBaseStackName}-DocDbPasswordSecretName"
+                    ListSecretName: ala-lists-base-development
+                    #  Fn::ImportValue:
+                    #    Fn::Sub: "${pBaseStackName}-DocDbPasswordSecretName"
                     MongoDbHost:
                       Fn::ImportValue:
                         Fn::Sub: "${pDatabaseStackName}-DocDbClusterEndpoint"

--- a/lists-service/src/main/java/au/org/ala/listsapi/service/AdminService.java
+++ b/lists-service/src/main/java/au/org/ala/listsapi/service/AdminService.java
@@ -35,7 +35,7 @@ public class AdminService {
   @Autowired protected SpeciesListItemMongoRepository speciesListItemMongoRepository;
   @Autowired protected SpeciesListIndexElasticRepository speciesListIndexElasticRepository;
   @Autowired protected ElasticsearchOperations elasticsearchOperations;
-  @Autowired protected  MongoTemplate mongoTemplate;
+  @Autowired protected MongoTemplate mongoTemplate;
 
   public void deleteDocs() {
     speciesListMongoRepository.deleteAll();


### PR DESCRIPTION
The secret is a resource for the whole product, it fits better in the base component. This change also removes the auto-generation of the db password. It means that it will have to be manually created and added to the secret but this happens infrequently. This was done to prevent accidental overwrite of the password when the db or base stack is run  