### PR TITLE
#419 Require authentication for file upload endpoint

### DIFF
--- a/lists-service/src/main/java/au/org/ala/listsapi/controller/IngressController.java
+++ b/lists-service/src/main/java/au/org/ala/listsapi/controller/IngressController.java
@@ -245,10 +245,9 @@ public class IngressController {
             description = "Bad Request",
             content = {@Content(mediaType = "text/plain")})
       })
-  public ResponseEntity<Object> handleFileUpload(@RequestPart("file") MultipartFile file, @AuthenticationPrincipal Principal principal) {
+  public ResponseEntity<Object> handleFileUpload(@RequestPart("file") MultipartFile file, @AuthenticationPrincipal AlaUserProfile profile) {
     // check user logged in
-    AlaUserProfile alaUserProfile = (AlaUserProfile) principal;
-    if (alaUserProfile == null) {
+    if (profile == null) {
       return ResponseEntity.badRequest().body("User not found");
     }
 

--- a/lists-service/src/main/java/au/org/ala/listsapi/controller/IngressController.java
+++ b/lists-service/src/main/java/au/org/ala/listsapi/controller/IngressController.java
@@ -245,7 +245,12 @@ public class IngressController {
             description = "Bad Request",
             content = {@Content(mediaType = "text/plain")})
       })
-  public ResponseEntity<Object> handleFileUpload(@RequestPart("file") MultipartFile file) {
+  public ResponseEntity<Object> handleFileUpload(@RequestPart("file") MultipartFile file, @AuthenticationPrincipal Principal principal) {
+    // check user logged in
+    AlaUserProfile alaUserProfile = (AlaUserProfile) principal;
+    if (alaUserProfile == null) {
+      return ResponseEntity.badRequest().body("User not found");
+    }
 
     try {
       logger.info("Upload to temporary area started...");


### PR DESCRIPTION
Added a Principal parameter to handleFileUpload and now check for a valid AlaUserProfile before proceeding. Returns a bad request if the user is not found, ensuring only authenticated users can upload files.