### PR TITLE
#306 Implemented security headers in SecurityConfig.java to address vulnerabilities

### DIFF
--- a/lists-service/config/lists-service-config.properties
+++ b/lists-service/config/lists-service-config.properties
@@ -1,5 +1,9 @@
 app.name=species-lists
 app.description=${app.name} is a Spring Boot application
+
+# Fix HTTP Header Information Disclosure vulnerability - hide server version
+server.server-header=
+
 spring.graphql.graphiql.enabled=true
 spring.graphql.graphiql.path=/graphiql
 elastic.host=elasticsearch:9200

--- a/lists-service/src/main/java/au/org/ala/listsapi/SecurityConfig.java
+++ b/lists-service/src/main/java/au/org/ala/listsapi/SecurityConfig.java
@@ -7,7 +7,8 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.annotation.Order;
-import org.springframework.security.config.annotation.method.configuration.EnableGlobalMethodSecurity;
+import org.springframework.security.config.Customizer;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.web.SecurityFilterChain;
@@ -18,7 +19,7 @@ import org.springframework.security.web.firewall.HttpFirewall;
 @Configuration
 @EnableWebSecurity
 @ComponentScan(basePackages = {"au.org.ala.ws.security", "au.org.ala.security.common"})
-@EnableGlobalMethodSecurity(securedEnabled = true)
+@EnableMethodSecurity(securedEnabled = true)
 @EnableCaching
 @Order(1)
 public class SecurityConfig {
@@ -29,9 +30,34 @@ public class SecurityConfig {
   public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
 
     http.addFilterBefore(alaWebServiceAuthFilter, BasicAuthenticationFilter.class);
-    http.authorizeRequests()
+    http.authorizeHttpRequests(auth -> auth
             .requestMatchers("/", "/graphql", "/ingest", "/graphiql", "/v1/species/**", "/**")
-            .permitAll();
+            .permitAll());
+
+    /*
+      Configure security headers to address vulnerabilities:
+      - Fix Missing HTTP Strict Transport Security Policy (Medium severity)
+      - Fix Missing 'X-Frame-Options' Header (Low severity) - prevents clickjacking
+      - Fix Missing 'X-Content-Type-Options' Header (Low severity) - prevents MIME sniffing
+      - Fix Missing Content Security Policy (Low severity) - prevents XSS attacks
+     */
+    http.headers(headers -> headers
+        .httpStrictTransportSecurity(hstsConfig -> hstsConfig
+            .maxAgeInSeconds(31536000) // 1 year
+            .includeSubDomains(true)
+            .preload(true))
+        .frameOptions(frameOptions -> frameOptions.deny())
+        .contentTypeOptions(Customizer.withDefaults())
+        .contentSecurityPolicy(csp -> csp.policyDirectives(
+            "default-src 'self'; " +
+                "script-src 'self' 'unsafe-inline' 'unsafe-eval'; " +
+                "style-src 'self' 'unsafe-inline'; " +
+                "img-src 'self' data: https:; " +
+                "font-src 'self' data:; " +
+                "connect-src 'self'; " +
+                "frame-ancestors 'none'; " +
+                "base-uri 'self'")));
+
     return http.csrf(httpSecurityCsrfConfigurer -> httpSecurityCsrfConfigurer.disable()).build();
   }
 

--- a/lists-service/src/main/resources/application.properties
+++ b/lists-service/src/main/resources/application.properties
@@ -2,6 +2,10 @@
 # These values can be overridden in the external configuration file at:
 # /data/lists-service/config/lists-service-config.properties
 # where any sensitive information should be stored.
+
+# Fix HTTP Header Information Disclosure vulnerability - hide server version
+server.server-header=
+
 app.name=lists-api
 app.version=1.0.0
 app.description=REST services for interacting with the ALA Species Lists API


### PR DESCRIPTION
### TLDR
- Added HSTS, X-Frame-Options, X-Content-Type-Options, and Content Security Policy.
- Suppressed server version disclosure in HTTP headers by setting server.server-header

# Vulnerabilities Fixed

## 1. Missing HTTP Strict Transport Security Policy (Medium Severity - CVSS 6.5)
**Issue**: The application was missing HSTS headers, making it vulnerable to man-in-the-middle attacks.

**Fix**: Added HSTS configuration in `SecurityConfig.java`:
```java
.httpStrictTransportSecurity(hstsConfig -> hstsConfig
    .maxAgeInSeconds(31536000) // 1 year
    .includeSubDomains(true)
    .preload(true))
```

**Result**: Browser will now enforce HTTPS connections for 1 year, including subdomains, and can be preloaded in browser HSTS lists.

## 2. Missing 'X-Frame-Options' Header (Low Severity - CVSS 3.1)
**Issue**: Application was vulnerable to clickjacking attacks as it didn't prevent embedding in frames.

**Fix**: Added frame options configuration in `SecurityConfig.java`:
```java
.frameOptions(frameOptions -> frameOptions.deny())
```

**Result**: Pages cannot be embedded in frames or iframes, preventing clickjacking attacks.

### 3. Missing 'X-Content-Type-Options' Header (Low Severity - CVSS 3.1)
**Issue**: Browser could perform MIME type sniffing, potentially leading to security issues.

**Fix**: Added content type options in `SecurityConfig.java`:
```java
.contentTypeOptions(Customizer.withDefaults())
```

**Result**: Browser will not perform MIME type sniffing and will respect the declared content type.

## 4. Missing Content Security Policy (Low Severity - CVSS 3.1)
**Issue**: Application was vulnerable to XSS and code injection attacks without CSP protection.

**Fix**: Added comprehensive CSP configuration in `SecurityConfig.java`:
```java
.contentSecurityPolicy(csp -> csp.policyDirectives(
    "default-src 'self'; " +
    "script-src 'self' 'unsafe-inline' 'unsafe-eval'; " +
    "style-src 'self' 'unsafe-inline'; " +
    "img-src 'self' data: https:; " +
    "font-src 'self' data:; " +
    "connect-src 'self'; " +
    "frame-ancestors 'none'; " +
    "base-uri 'self'"
))
```

**Result**: Browser will enforce restrictions on resource loading, preventing many types of XSS and injection attacks.

## 5. HTTP Header Information Disclosure (Low Severity - CVSS 3.1)
**Issue**: Server was exposing version information in HTTP headers (e.g., "Server: AmazonS3").

**Fix**: Added server header suppression in both configuration files:
- `src/main/resources/application.properties`
- `config/lists-service-config.properties`

Configuration added:
```properties
# Fix HTTP Header Information Disclosure vulnerability - hide server version
server.server-header=
```

**Result**: Server version information is no longer disclosed in HTTP response headers.

## Testing Recommendations

After deployment, verify the fixes by:
1. Checking that HSTS headers are present: `Strict-Transport-Security: max-age=31536000; includeSubDomains; preload`
2. Verifying X-Frame-Options header: `X-Frame-Options: DENY`
3. Confirming X-Content-Type-Options: `X-Content-Type-Options: nosniff`
4. Validating CSP header is present with the configured policy
5. Ensuring no server version information is disclosed in response headers

## Implementation Notes

- The security headers are configured at the Spring Security level, ensuring they apply to all responses
- The CSP policy includes `unsafe-inline` and `unsafe-eval` for scripts to maintain compatibility with existing functionality - this should be reviewed and tightened if possible
- Server header suppression is configured at the Spring Boot application level
- All fixes use modern Spring Security 6.1+ API methods
