### PR TITLE
#282 Authentication fixes

### DIFF
--- a/lists-service/src/main/java/au/org/ala/listsapi/SecurityConfig.java
+++ b/lists-service/src/main/java/au/org/ala/listsapi/SecurityConfig.java
@@ -11,6 +11,8 @@ import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.annotation.web.configurers.HeadersConfigurer;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.www.BasicAuthenticationFilter;
 import org.springframework.security.web.firewall.DefaultHttpFirewall;
@@ -46,7 +48,7 @@ public class SecurityConfig {
             .maxAgeInSeconds(31536000) // 1 year
             .includeSubDomains(true)
             .preload(true))
-        .frameOptions(frameOptions -> frameOptions.deny())
+        .frameOptions(HeadersConfigurer.FrameOptionsConfig::deny)
         .contentTypeOptions(Customizer.withDefaults())
         .contentSecurityPolicy(csp -> csp.policyDirectives(
             "default-src 'self'; " +
@@ -58,7 +60,7 @@ public class SecurityConfig {
                 "frame-ancestors 'none'; " +
                 "base-uri 'self'")));
 
-    return http.csrf(httpSecurityCsrfConfigurer -> httpSecurityCsrfConfigurer.disable()).build();
+    return http.csrf(AbstractHttpConfigurer::disable).build();
   }
 
   @Bean

--- a/lists-ui/src/App.tsx
+++ b/lists-ui/src/App.tsx
@@ -1,51 +1,36 @@
 /// <reference types="vite-plugin-svgr/client" />
 
-import { useEffect, useState } from 'react';
+import { useEffect } from 'react';
 
 // Routing
-import { RouterProvider } from 'react-router/dom';
 import { NuqsAdapter } from 'nuqs/adapters/react-router/v7';
+import { RouterProvider } from 'react-router/dom';
 import routes from './Router';
 
 // Authentication
 import { useAuth } from 'react-oidc-context';
-import handleSignout from './helpers/auth/handleSignout';
 
 // Local components
 import PageLoader from './components/PageLoader';
+import handleRefresh from './helpers/auth/handleRefresh';
 
 function App() {
   const auth = useAuth();
-  const [silentRenew, setSilentRenew] = useState<boolean>(false);
 
   useEffect(() => {
     if (auth.isAuthenticated) {
-      // Create an interval to silently refresh the token
-      const interval = setInterval(async () => {
-        if (
-          auth.isAuthenticated &&
-          !auth.isLoading &&
-          (auth.user?.expires_in || 0) <= 60
-        ) {
-          setSilentRenew(true);
+      const accessTokenExpiringCallback = () => handleRefresh(auth);
 
-          try {
-            await auth.signinSilent();
-          } catch (error) {
-            // Sign out if the token renewal wasn't successful
-            handleSignout(auth);
-          }
-
-          setSilentRenew(false);
-        }
-      }, 1000);
-
-      return () => clearInterval(interval);
+      auth.events.addAccessTokenExpiring(accessTokenExpiringCallback);
+      return () =>
+        auth.events.removeAccessTokenExpiring(accessTokenExpiringCallback);
+    } else {
+      auth.removeUser();
     }
-  }, [auth]);
+  }, [auth.isAuthenticated]);
 
   // If the user hasn't been authenticated, show a page loader instead
-  return auth.isLoading && !silentRenew ? (
+  return auth.isLoading ? (
     <div style={{ width: '100vw', height: '100vh' }}>
       <PageLoader />
     </div>

--- a/lists-ui/src/App.tsx
+++ b/lists-ui/src/App.tsx
@@ -20,7 +20,6 @@ function App() {
   useEffect(() => {
     if (auth.isAuthenticated) {
       const refreshInterval = setInterval(async () => {
-        console.log(auth.user?.expires_in);
         if ((auth.user?.expires_in || 0) < 60) await handleRefresh(auth);
       }, 1000);
 

--- a/lists-ui/src/App.tsx
+++ b/lists-ui/src/App.tsx
@@ -19,13 +19,12 @@ function App() {
 
   useEffect(() => {
     if (auth.isAuthenticated) {
-      const accessTokenExpiringCallback = () => handleRefresh(auth);
+      const refreshInterval = setInterval(async () => {
+        console.log(auth.user?.expires_in);
+        if ((auth.user?.expires_in || 0) < 60) await handleRefresh(auth);
+      }, 1000);
 
-      auth.events.addAccessTokenExpiring(accessTokenExpiringCallback);
-      return () =>
-        auth.events.removeAccessTokenExpiring(accessTokenExpiringCallback);
-    } else {
-      auth.removeUser();
+      return () => clearInterval(refreshInterval);
     }
   }, [auth.isAuthenticated]);
 

--- a/lists-ui/src/api/graphql/performGQLQuery.ts
+++ b/lists-ui/src/api/graphql/performGQLQuery.ts
@@ -9,7 +9,7 @@ async function performGQLQuery<T = any>(
 ): Promise<T> {
   const headers: HeadersInit = {
     'Content-Type': 'application/json',
-    ...(token ? { Authorization: `Bearer ${token}` } : {}),
+    ...((token && token.trim() !== '') ? { Authorization: `Bearer ${token}` } : {}),
   };
 
   const response = await fetch(

--- a/lists-ui/src/api/rest/lists.ts
+++ b/lists-ui/src/api/rest/lists.ts
@@ -1,3 +1,4 @@
+import { FileWithPath } from '@mantine/dropzone';
 import { request } from './query';
 
 import {
@@ -7,7 +8,6 @@ import {
   SpeciesListSubmit,
   UploadResult,
 } from '../graphql/types';
-import { FileWithPath } from '@mantine/dropzone';
 
 const listToForm = (list: SpeciesListSubmit, file: string): FormData => {
   // Create a new FormData object
@@ -41,15 +41,21 @@ export default (token: string) => ({
       token
     ),
   download: async (id: string): Promise<void> => {
+    const headers: HeadersInit = {};
+    
+    // Only include Authorization header if we have a valid token
+    // If token is empty string, don't send Authorization header
+    if (token && token.trim() !== '') {
+      headers.Authorization = `Bearer ${token}`;
+    }
+    
     const response = await fetch(
       `${import.meta.env.VITE_API_BASEURL}${
         import.meta.env.VITE_API_LIST_DOWNLOAD
       }/${id}`,
       {
         method: 'GET',
-        headers: {
-          Authorization: `Bearer ${token}`,
-        },
+        headers,
       }
     );
 

--- a/lists-ui/src/api/rest/query.ts
+++ b/lists-ui/src/api/rest/query.ts
@@ -5,7 +5,7 @@ export const request = async <T>(
   token?: string,
   additionalHeaders?: HeadersInit
 ): Promise<T> => {
-  const headers: HeadersInit = token
+  const headers: HeadersInit = (token && token.trim() !== '')
     ? { Authorization: `Bearer ${token}`, ...(additionalHeaders || {}) }
     : additionalHeaders || {};
 

--- a/lists-ui/src/helpers/auth/handleRefresh.ts
+++ b/lists-ui/src/helpers/auth/handleRefresh.ts
@@ -47,7 +47,7 @@ export default async function handleRefresh(auth: AuthContextProps) {
   // Update the existing user
   existing.access_token = access_token;
   existing.expires_in = expires_in;
-  existing.expires_at = Date.now() + expires_in * 1000;
+  existing.expires_at = Math.floor(Date.now() / 1000) + expires_in;
 
   // Trigger the user event to propagate changes & update localStorage
   await auth.events.load(existing, true);

--- a/lists-ui/src/helpers/auth/handleRefresh.ts
+++ b/lists-ui/src/helpers/auth/handleRefresh.ts
@@ -1,0 +1,55 @@
+import { userManager } from '#/main';
+import { AuthContextProps } from 'react-oidc-context';
+import handleSignout from './handleSignout';
+
+interface TokenRefreshPayload {
+  access_token: string;
+  expires_in: number;
+  id_token: string;
+  token_type: string;
+}
+
+export default async function handleRefresh(auth: AuthContextProps) {
+  // Ensure the user exists
+  let existing = auth.user;
+  if (!existing) {
+    await handleSignout(auth);
+    return;
+  }
+
+  // Construct the form data for the request
+  const params = new URLSearchParams({
+    grant_type: 'refresh_token',
+    client_id: import.meta.env.VITE_AUTH_CLIENT_ID,
+    refresh_token: auth.user?.refresh_token || '',
+  });
+
+  // Make the token refresh request
+  const tokenEndpoint = await userManager.metadataService.getTokenEndpoint();
+  const resp = await fetch(tokenEndpoint || '', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/x-www-form-urlencoded',
+    },
+    body: params.toString(),
+  });
+
+  // If we couldn't get the token okay, sign out
+  if (!resp.ok) {
+    await handleSignout(auth);
+    return;
+  }
+
+  // Extract the token payload data
+  const { access_token, expires_in } =
+    (await resp.json()) as TokenRefreshPayload;
+
+  // Update the existing user
+  existing.access_token = access_token;
+  existing.expires_in = expires_in;
+  existing.expires_at = Date.now() + expires_in * 1000;
+
+  // Trigger the user event to propagate changes & update localStorage
+  await auth.events.load(existing, true);
+  await userManager.storeUser(existing);
+}

--- a/lists-ui/src/helpers/context/ALAProvider.tsx
+++ b/lists-ui/src/helpers/context/ALAProvider.tsx
@@ -1,14 +1,14 @@
+import { faLock } from '@fortawesome/free-solid-svg-icons';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { notifications } from '@mantine/notifications';
 import { PropsWithChildren } from 'react';
 import { useAuth } from 'react-oidc-context';
-import { notifications } from '@mantine/notifications';
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { faLock } from '@fortawesome/free-solid-svg-icons';
 
-import ALAContext from './ALAContext';
-import { SpeciesList } from '../../api';
 import rest from '#/api/rest';
-import classes from '../../Notifications.module.css';
 import { useIntl } from 'react-intl';
+import { SpeciesList } from '../../api';
+import classes from '../../Notifications.module.css';
+import ALAContext from './ALAContext';
 
 const JWT_ROLES = import.meta.env.VITE_AUTH_JWT_ROLES;
 const JWT_USERID = import.meta.env.VITE_AUTH_JWT_USERID;
@@ -51,7 +51,7 @@ export const ALAProvider = ({ children }: PropsWithChildren) => {
         userid,
         roles,
         showAuthRequiredNotification,
-        rest: rest(auth.user?.access_token || '', isAdmin),
+        rest: rest(auth.isAuthenticated ? auth.user?.access_token || '' : '', isAdmin),
         isAdmin,
         isAuthenticated: auth.isAuthenticated,
         isAuthorisedForList,

--- a/lists-ui/src/main.tsx
+++ b/lists-ui/src/main.tsx
@@ -27,8 +27,8 @@ export const userManager = new UserManager({
   client_id: import.meta.env.VITE_AUTH_CLIENT_ID,
   redirect_uri: import.meta.env.VITE_AUTH_REDIRECT_URI,
   scope: import.meta.env.VITE_AUTH_SCOPE,
-  // tell it to persist into localStorage
   userStore: new WebStorageStateStore({ store: window.localStorage }),
+  automaticSilentRenew: false,
 });
 
 function Main() {

--- a/lists-ui/src/main.tsx
+++ b/lists-ui/src/main.tsx
@@ -1,7 +1,7 @@
 // Global styles
 import '@mantine/core/styles.css';
-import '@mantine/nprogress/styles.css';
 import '@mantine/notifications/styles.css';
+import '@mantine/nprogress/styles.css';
 
 import { theme } from '@atlasoflivingaustralia/ala-mantine';
 import { MantineProvider } from '@mantine/core';
@@ -10,8 +10,8 @@ import { Notifications } from '@mantine/notifications';
 import notificationStyles from './Notifications.module.css';
 
 // Authentication
+import { UserManager, WebStorageStateStore } from 'oidc-client-ts';
 import { AuthProvider } from 'react-oidc-context';
-import { WebStorageStateStore } from 'oidc-client-ts';
 import handleCallback from './helpers/auth/handleCallback';
 import { ALAProvider } from './helpers/context/ALAProvider';
 
@@ -22,26 +22,25 @@ import en from './locale/en.json';
 // Application
 import App from './App';
 
-// Use localStorage for user persistence
-const userStore = new WebStorageStateStore({ store: localStorage });
+export const userManager = new UserManager({
+  authority: import.meta.env.VITE_AUTH_AUTHORITY,
+  client_id: import.meta.env.VITE_AUTH_CLIENT_ID,
+  redirect_uri: import.meta.env.VITE_AUTH_REDIRECT_URI,
+  scope: import.meta.env.VITE_AUTH_SCOPE,
+  // tell it to persist into localStorage
+  userStore: new WebStorageStateStore({ store: window.localStorage }),
+});
 
 function Main() {
   return (
-    <AuthProvider
-      client_id={import.meta.env.VITE_AUTH_CLIENT_ID}
-      redirect_uri={import.meta.env.VITE_AUTH_REDIRECT_URI}
-      authority={import.meta.env.VITE_AUTH_AUTHORITY}
-      scope={import.meta.env.VITE_AUTH_SCOPE}
-      userStore={userStore}
-      onSigninCallback={handleCallback}
-    >
+    <AuthProvider userManager={userManager} onSigninCallback={handleCallback}>
       <MantineProvider theme={theme}>
         <IntlProvider messages={en} locale='en'>
           <ModalsProvider modalProps={{ radius: 'lg' }}>
             <ALAProvider>
               <Notifications
                 transitionDuration={400}
-                position="top-right"
+                position='top-right'
                 classNames={notificationStyles}
               />
               <App />


### PR DESCRIPTION
**From the issue:**

This warrants a bit of a write up as I went down a bit of a rabbit hole to fix this one.

The 'silent renew' functionality built into `oidc-client-ts` doesn't work for Cognito, as it embeds an invisible frame into the page to handle the request in the background. However, Cognito doesn't allow frame embedding for their authentication pages and the request fails silently.

The fix was to swap out the `auth.signInSilent()` call in the `setInterval` callback in `App.tsx` with a custom bit of code (`helpers/handleRefresh.ts`) that takes the refresh token, makes the new `access_token` request, force updates the `oidc-client-ts` state (both in memory and in localStorage) with the new token & expiry. To update localStorage, I had to define the  `userManager` separately and pass it to the <AuthProvider> in `main.tsx`, so I could get access to both the token endpoint returned from the OIDC discovery document, and the `storeUser` function (so I didn't need to implement a new function to manually update localStorage with the new token details).

I looked into using the events supplied `oidc-client-ts` (i.e. `addAccessTokenExpiring`), but found a few issues (see https://github.com/authts/oidc-client-ts/issues/1624)

`oidc-client-ts` (and `react-oidc-context` by proxy) are janky, and don't seem like they're actively maintained looking at their repositories.