### PR TITLE
Add M2M authorization with `ala/internal` scope

### DIFF
--- a/lists-service/src/main/java/au/org/ala/listsapi/controller/GraphQLController.java
+++ b/lists-service/src/main/java/au/org/ala/listsapi/controller/GraphQLController.java
@@ -203,7 +203,7 @@ public class GraphQLController {
         }
 
         NativeQueryBuilder builder = NativeQuery.builder().withPageable(PageRequest.of(1, 1));
-        Boolean isAdmin = principal != null ? authUtils.hasAdminRole(authUtils.getUserProfile(principal)) : false;
+        Boolean isAdmin = principal != null ? (authUtils.hasAdminRole(authUtils.getUserProfile(principal)) || authUtils.hasInternalScope(authUtils.getUserProfile(principal))) : false;
         String finalUserId = getUserIdBasedOnRole(isPrivate, userId, principal, isAdmin);
 
         if ("relevance".equalsIgnoreCase(sort) && StringUtils.isNotBlank(searchQuery)) {
@@ -869,7 +869,7 @@ public class GraphQLController {
         NativeQueryBuilder builder = NativeQuery.builder().withPageable(pageableRequest);
         AlaUserProfile profile = authUtils.getUserProfile(principal);
         String userId = profile != null ? profile.getUserId() : null;
-        Boolean isAdmin = authUtils.hasAdminRole(profile);
+        Boolean isAdmin = authUtils.hasAdminRole(profile) || authUtils.hasInternalScope(profile);
         builder.withQuery(
                 q -> q.bool(
                         bq -> {
@@ -925,7 +925,7 @@ public class GraphQLController {
         // applied.
         // ElasticUtils.cleanRawQuery will handle a null searchQuery, typically
         // returning an empty string.
-        Boolean isAdmin = authUtils.hasAdminRole(authUtils.getUserProfile(principal));
+        Boolean isAdmin = authUtils.hasAdminRole(authUtils.getUserProfile(principal)) || authUtils.hasInternalScope(authUtils.getUserProfile(principal));
         String finalUserId = getUserIdBasedOnRole(isPrivate, userId, principal, isAdmin);
 
         builder.withQuery(
@@ -1080,7 +1080,7 @@ public class GraphQLController {
             }
         }
 
-        Boolean isAdmin = principal != null ? authUtils.hasAdminRole(authUtils.getUserProfile(principal)) : false;
+        Boolean isAdmin = principal != null ? (authUtils.hasAdminRole(authUtils.getUserProfile(principal)) || authUtils.hasInternalScope(authUtils.getUserProfile(principal))) : false;
         String finalUserId;
 
         if (principal != null) {

--- a/lists-service/src/main/java/au/org/ala/listsapi/controller/IngressController.java
+++ b/lists-service/src/main/java/au/org/ala/listsapi/controller/IngressController.java
@@ -345,7 +345,7 @@ public class IngressController {
     // check user logged in
     AlaUserProfile alaUserProfile = (AlaUserProfile) principal;
     if (alaUserProfile == null) {
-      return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body("The user ");
+      return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body("You must be authenticated to get the ingest progress of a list.");
     }
 
     IngestProgressItem ingestProgress = progressService.getIngestProgress(speciesListID);

--- a/lists-service/src/main/java/au/org/ala/listsapi/controller/RESTController.java
+++ b/lists-service/src/main/java/au/org/ala/listsapi/controller/RESTController.java
@@ -133,11 +133,12 @@ public class RESTController {
             Pageable paging = PageRequest.of(page - 1, pageSize);
 
             if (!authUtils.isAuthenticated(principal)) {
-                logger.info(Boolean.toString(authUtils.isAuthenticated(principal)));
                 if (eq(speciesList.getIsPrivate(), "true")) {
                     return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
                             .body("You must be authenticated to query private lists");
                 }
+
+                speciesList.setIsPrivate("false");
             } else {
                 AlaUserProfile profile = authUtils.getUserProfile(principal);
 


### PR DESCRIPTION
- Treats the `ala/internal` scope as a special role for M2M tokens, granting them admin access to species lists.
- Updates `AuthUtils`, `RESTController`, `GraphQLController`, and `SearchHelperService` to recognize and handle this scope
- Adds tests for internal scope behavior.
- Fixes incomplete HTTP error response text

**IMPORTANT**
- Fixes security hole with unauthenticated users able to query all lists