### PR TITLE
Add support for URL redirect from lists-test

### DIFF
--- a/cicd/backend/pipeline/export_config_buildspec.yaml
+++ b/cicd/backend/pipeline/export_config_buildspec.yaml
@@ -222,6 +222,7 @@ phases:
           branch: "${CLEAN_BRANCH}"
           version: "${COMMIT_ID}"
           Name: "${HELM_RELEASE_NAME}"
+        environment: "${ENVIRONMENT}"
         resources:
           requests:
             cpu: "${CPU_REQUEST}"      

--- a/config.ini
+++ b/config.ini
@@ -53,7 +53,7 @@ COGNITO_STACK_NAME = ala-cognito-pool-testing
 
 HOSTED_ZONE = test.ala.org.au
 
-APP_CERTIFICATE = arn:aws:acm:ap-southeast-2:748909248546:certificate/d866578c-8ad1-4462-9485-14472e1410fc
+APP_CERTIFICATE = arn:aws:acm:ap-southeast-2:748909248546:certificate/506d78ff-d909-4c89-8cc7-660a30305982
 CLOUDFRONT_CERTIFICATE = arn:aws:acm:us-east-1:748909248546:certificate/dd739e47-f989-4181-ad28-34518473eff4
 
 REGOLITH_STACK_NAME = ala-regolith-cluster-testing

--- a/lists-service/helm/templates/ingress.yaml
+++ b/lists-service/helm/templates/ingress.yaml
@@ -39,4 +39,16 @@ spec:
               name: svc-{{ include "ala-species-lists.fullname" . }}
               port:
                 number: {{ .Values.service.port }}
+    {{- if eq .Values.environment "testing" }}
+    - host: lists-test.ala.org.au
+      http:
+        paths:
+          - pathType: Prefix
+            path: /
+            backend:
+              service:
+                name: svc-{{ include "ala-species-lists.fullname" . }}
+                port:
+                  number: {{ .Values.service.port }}
+    {{- end }}
 {{- end }}

--- a/lists-service/helm/values.yaml
+++ b/lists-service/helm/values.yaml
@@ -47,6 +47,8 @@ resources:
     memory: 4096Mi
     cpu: 2
 
+environment: ""
+
 tags:
   branch: ""
   component: ""


### PR DESCRIPTION
#545 

Cloudfront uses a different certificate that is present in the us-east-1 region. I havent updated that yet, but if it is required then we will have to generate a new certificate that has both hosted zones of *.test.ala.org.au and *ala.org.au