### PR TITLE
fix: reindex species lists after field mutations

### DIFF
--- a/lists-service/src/main/java/au/org/ala/listsapi/controller/GraphQLController.java
+++ b/lists-service/src/main/java/au/org/ala/listsapi/controller/GraphQLController.java
@@ -429,7 +429,9 @@ public class GraphQLController {
             }
         }
 
-        return speciesListMongoRepository.save(toUpdate);
+        SpeciesList savedList = speciesListMongoRepository.save(toUpdate);
+        taxonService.reindex(savedList.getId());
+        return savedList;
     }
 
     @SchemaMapping(typeName = "Mutation", field = "renameField")
@@ -480,7 +482,9 @@ public class GraphQLController {
                 lastId = items.get(items.size() - 1).getId();
             }
         }
-        return speciesListMongoRepository.save(toUpdate);
+        SpeciesList savedList = speciesListMongoRepository.save(toUpdate);
+        taxonService.reindex(savedList.getId());
+        return savedList;
     }
 
     @SchemaMapping(typeName = "Mutation", field = "removeField")
@@ -529,7 +533,9 @@ public class GraphQLController {
             }
         }
 
-        return speciesListMongoRepository.save(toUpdate);
+        SpeciesList savedList = speciesListMongoRepository.save(toUpdate);
+        taxonService.reindex(savedList.getId());
+        return savedList;
     }
 
     @SchemaMapping(typeName = "Mutation", field = "updateSpeciesListItem")

--- a/lists-service/src/test/java/au/org/ala/listsapi/controller/GraphQLControllerTest.java
+++ b/lists-service/src/test/java/au/org/ala/listsapi/controller/GraphQLControllerTest.java
@@ -3,6 +3,7 @@ package au.org.ala.listsapi.controller;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.*;
 
 import java.security.Principal;
@@ -215,5 +216,80 @@ class GraphQLControllerTest {
         verify(speciesListMongoRepository).findByIdOrDataResourceUid("dr1234", "dr1234");
         verify(speciesListItemMongoRepository, times(2)).save(any());
         verify(taxonService).lookupTaxon(any());
+    }
+
+    @Test
+    void testAddField_ReindexesList() {
+        String listId = "list123";
+        SpeciesList list = new SpeciesList();
+        list.setId(listId);
+        list.setFieldList(new ArrayList<>());
+        
+        when(speciesListMongoRepository.findByIdOrDataResourceUid(listId, listId))
+                .thenReturn(Optional.of(list));
+        when(authUtils.isAuthorized(list, principal)).thenReturn(true);
+        when(speciesListMongoRepository.save(any(SpeciesList.class))).thenAnswer(i -> i.getArgument(0));
+        
+        // Mock the pagination for finding items
+        when(speciesListItemMongoRepository.findNextBatch(eq(listId), isNull(), any(PageRequest.class)))
+                .thenReturn(new ArrayList<>());
+
+        SpeciesList result = graphQLController.addField(listId, "newField", "defaultValue", principal);
+
+        assertNotNull(result);
+        assertTrue(result.getFieldList().contains("newField"));
+        verify(speciesListMongoRepository).save(list);
+        verify(taxonService).reindex(listId);
+    }
+
+    @Test
+    void testRenameField_ReindexesList() {
+        String listId = "list123";
+        SpeciesList list = new SpeciesList();
+        list.setId(listId);
+        List<String> fields = new ArrayList<>();
+        fields.add("oldField");
+        list.setFieldList(fields);
+        
+        when(speciesListMongoRepository.findByIdOrDataResourceUid(listId, listId))
+                .thenReturn(Optional.of(list));
+        when(authUtils.isAuthorized(list, principal)).thenReturn(true);
+        when(speciesListMongoRepository.save(any(SpeciesList.class))).thenAnswer(i -> i.getArgument(0));
+        
+        when(speciesListItemMongoRepository.findNextBatch(eq(listId), isNull(), any(PageRequest.class)))
+                .thenReturn(new ArrayList<>());
+
+        SpeciesList result = graphQLController.renameField(listId, "oldField", "newField", principal);
+
+        assertNotNull(result);
+        assertFalse(result.getFieldList().contains("oldField"));
+        assertTrue(result.getFieldList().contains("newField"));
+        verify(speciesListMongoRepository).save(list);
+        verify(taxonService).reindex(listId);
+    }
+
+    @Test
+    void testRemoveField_ReindexesList() {
+        String listId = "list123";
+        SpeciesList list = new SpeciesList();
+        list.setId(listId);
+        List<String> fields = new ArrayList<>();
+        fields.add("fieldToRemove");
+        list.setFieldList(fields);
+        
+        when(speciesListMongoRepository.findByIdOrDataResourceUid(listId, listId))
+                .thenReturn(Optional.of(list));
+        when(authUtils.isAuthorized(list, principal)).thenReturn(true);
+        when(speciesListMongoRepository.save(any(SpeciesList.class))).thenAnswer(i -> i.getArgument(0));
+        
+        when(speciesListItemMongoRepository.findNextBatch(eq(listId), isNull(), any(PageRequest.class)))
+                .thenReturn(new ArrayList<>());
+
+        SpeciesList result = graphQLController.removeField(listId, "fieldToRemove", principal);
+
+        assertNotNull(result);
+        assertFalse(result.getFieldList().contains("fieldToRemove"));
+        verify(speciesListMongoRepository).save(list);
+        verify(taxonService).reindex(listId);
     }
 }


### PR DESCRIPTION
Fixes #695.

When a user mutated custom fields via UI (rename, remove, update), the updates were saved in MongoDB via bulk operations but the affected list was never reindexed in Elasticsearch. This caused a synchronization issue where the UI (fetching from ES) would no longer show the column data because the keys had diverged, until a rematch was triggered manually.

This fix forces an immediate reindex of the updated list after any schema mutations (`renameField`, `removeField`, `updateSpeciesListItem`).