### PR TITLE
Feature/waf tokendomain

### DIFF
--- a/cicd/backend/app/waf.yaml
+++ b/cicd/backend/app/waf.yaml
@@ -38,6 +38,11 @@ Resources:
         SampledRequestsEnabled: true
         CloudWatchMetricsEnabled: true
         MetricName: !Sub ${pEnvironment}-lists-DefaultAction
+      Tags:
+        - Key: Name
+          Value: !Sub lists-eks-${pEnvironment}-backend
+      TokenDomains:
+        - ala.org.au
       Rules:
         - Name: ALAHostHeaderCheck
           Priority: 0

--- a/cicd/frontend/app/waf.yaml
+++ b/cicd/frontend/app/waf.yaml
@@ -46,6 +46,11 @@ Resources:
         SampledRequestsEnabled: true
         CloudWatchMetricsEnabled: true
         MetricName: !Sub lists-waf-wacl-${pCleanBranch}
+      Tags:
+        - Key: Name
+          Value: !Sub lists-eks-${pEnvironment}-frontend
+      TokenDomains:
+        - ala.org.au
       Rules:
         - Name: ip-allowlist
           Action:

--- a/cicd/frontend/app/waf.yaml
+++ b/cicd/frontend/app/waf.yaml
@@ -36,7 +36,7 @@ Resources:
     Type: AWS::WAFv2::WebACL
     Properties:
       Name: !Sub
-        - "lists-${ResourceName}"
+        - "lists-frontend-${ResourceName}"
         - ResourceName: !If [ IsDev, !Ref pCleanBranch, !Ref pEnvironment ]
       Description: LISTS Web ACL
       Scope: CLOUDFRONT
@@ -101,6 +101,26 @@ Resources:
             ManagedRuleGroupStatement:
               VendorName: AWS
               Name: AWSManagedRulesKnownBadInputsRuleSet
+
+  ListsLoggingConfiguration:
+    Type: AWS::WAFv2::LoggingConfiguration
+    Properties:
+      ResourceArn: !GetAtt ListsWafWebACL.Arn
+      LogDestinationConfigs:
+        - !GetAtt ListsWafLogGroup.Arn 
+
+  ListsWafLogGroup:
+    Type: AWS::Logs::LogGroup
+    DeletionPolicy: Delete
+    Properties:
+      LogGroupName: !Sub 
+                       - aws-waf-logs-${pEnvironment}/${ListsWafName}-ia
+                       - ListsWafName: !Select [ 0, !Split [ '|', !Ref ListsWafWebACL]]
+      LogGroupClass: INFREQUENT_ACCESS
+      RetentionInDays: 14
+      Tags:
+        - Key: Name
+          Value: !Ref AWS::StackName
 
 Outputs:
  ListsWafWebAclArn:

--- a/cicd/frontend/app/waf.yaml
+++ b/cicd/frontend/app/waf.yaml
@@ -101,9 +101,6 @@ Resources:
             ManagedRuleGroupStatement:
               VendorName: AWS
               Name: AWSManagedRulesKnownBadInputsRuleSet
-      Tags:
-        - Key: Environment
-          Value: !Ref pEnvironment
 
 Outputs:
  ListsWafWebAclArn:


### PR DESCRIPTION
Adding a tokenDomain ensures tokens set on any ala subdomain will be accepted here

https://docs.aws.amazon.com/AWSCloudFormation/latest/TemplateReference/aws-resource-wafv2-webacl.html#cfn-wafv2-webacl-tokendomains

This was done in response to "Cookie “aws-waf-token” has been rejected for invalid domain." error messages appearing as a console error on the explore your area page, unsure if it's related but we should have a tokenDomain anyway

Also added a Name tag to help with cost and usage reporting