### PR TITLE
Update namematching url in dev and testing

### DIFF
--- a/cicd/backend/config.ini
+++ b/cicd/backend/config.ini
@@ -33,6 +33,7 @@ MULTIPART_MAX_REQUEST_SIZE = 50MB
 MONGODB_PORT = 27017
 MONGODB_AUTO_INDEX_CREATION = true
 
+# Update nm url to http://svc-ala-namematching-production.apps.svc.cluster.local/ when eks namematching service is deployed to production
 NAMEMATCHING_BASE_URL = https://namematching-ws.ala.org.au/
 BIE_BASE_URL = https://bie-ws.ala.org.au/ws
 BIE_URL = https://bie-ws.ala.org.au/ws/species/%s
@@ -93,7 +94,7 @@ PIPELINE_STACK_NAME = ala-${PRODUCT_NAME}-${PRODUCT_COMPONENT}-pipeline-${CLEAN_
 HELM_RELEASE_NAME = ala-species-lists-${CLEAN_BRANCH}
 # For DEV env only, allow localhost:5173 for UI dev server
 APP_URL = https://${UI_SUB_DOMAIN}.${HOSTED_ZONE},http://localhost:5173
-NAMEMATCHING_BASE_URL = https://namematching-ws.test.ala.org.au/
+NAMEMATCHING_BASE_URL = http://svc-ala-namematching-testing.testing.svc.cluster.local/
 BIE_BASE_URL = https://bie-ws-test.ala.org.au/ws
 BIE_URL = https://bie-ws-test.ala.org.au/ws/species/%s
 BIE_IMAGES_URL = "https://bie-ws-test.ala.org.au/ws/imageSearch/%s?rows=%s&start=%s"
@@ -127,7 +128,7 @@ COMMON_WAF_RULE_GROUP_STACK_NAME = ala-bedrock-waf-common-waf-rule-group-testing
 
 EKS_NAMESPACE = testing
 
-NAMEMATCHING_BASE_URL = https://namematching-ws.test.ala.org.au/
+NAMEMATCHING_BASE_URL = http://svc-ala-namematching-testing.testing.svc.cluster.local/
 BIE_BASE_URL = https://bie-ws-test.ala.org.au/ws
 BIE_URL = https://bie-ws-test.ala.org.au/ws/species/%s
 BIE_IMAGES_URL = "https://bie-ws-test.ala.org.au/ws/imageSearch/%s?rows=%s&start=%s"


### PR DESCRIPTION
 In-cluster apps should just hit the ClusterIP service directly rather than looping out through a WAF/ALB