### PR TITLE
Reset page number when page size changes on home list view

### DIFF
--- a/lists-ui/src/views/Home/index.tsx
+++ b/lists-ui/src/views/Home/index.tsx
@@ -488,7 +488,10 @@ const Home = ({ routeId }: { routeId: string }) => {
               <Select
                 w={110}
                 value={size?.toString()}
-                onChange={(newSize) => setSize(parseInt(newSize || '10', 10))}
+                onChange={(newSize) => {
+                  setPage(0); // Reset 'page' when page size is changed
+                  setSize(parseInt(newSize || '10', 10));
+                }}
                 data={['10', '20', '50', '100'].map((value) => ({
                   label: `${value} items`,
                   value,


### PR DESCRIPTION
Fixes: #778

When a user changed the page size on the home list view while already on a later page, the frontend kept the current page index and requested results beyond the filtered total. This produced the backend error `fromIndex(100) > toIndex(70)`.

Reset the page index to `0` whenever the page size changes, matching the existing behaviour for search, filters, sort and reset actions. This ensures the paginated query starts from the first result and avoids requesting an invalid offset.

Changes:
- `lists-ui/src/views/Home/index.tsx`: reset `page` to `0` in the page-size `Select` `onChange` handler.