### PR TITLE
Serverless DocumentDB

### DIFF
--- a/cicd/database/app/database.yaml
+++ b/cicd/database/app/database.yaml
@@ -175,7 +175,7 @@ Resources:
       VpcSecurityGroupIds:
         - !Ref DocDbSecurityGrp
 
-  DocDbInstance:
+  DocDbProvisionedInstance:
     Type: AWS::DocDB::DBInstance
     Condition: IsProvisioned
     Properties:
@@ -204,12 +204,6 @@ Resources:
             - ResourceName: !If [ IsDev, !Ref pCleanBranch, !Ref pEnvironment ]
 
 Outputs:
-
-  DocDbMode:
-    Description: The capacity mode of the DocumentDB cluster
-    Value: !Ref pDbMode
-    Export:
-      Name: !Sub ${AWS::StackName}-DocDbMode
 
   DocDbUsername:
     Description: The DocumentDB username

--- a/cicd/database/app/database.yaml
+++ b/cicd/database/app/database.yaml
@@ -1,6 +1,6 @@
 AWSTemplateFormatVersion: '2010-09-09'
 
-Description: 'A DocumentDB Cluster with AutoScaling'
+Description: 'A DocumentDB Cluster, provisioned or serverless (Serverless V2)'
 
 Parameters:
   pAdminUser:
@@ -21,6 +21,15 @@ Parameters:
     Description: The DocumentDB engine version
     Type: String
     Default: 4.0.0
+  pDbMode:
+    Description: >-
+      The capacity mode of the DocumentDB cluster. Serverless (Serverless V2)
+      requires an engine version of 5.0.0 or later.
+    Type: String
+    AllowedValues:
+      - provisioned
+      - serverless
+    Default: provisioned
   pDbParameterGroupFamily:
     Description: The DocumentDB parameter group family
     Type: String
@@ -40,7 +49,7 @@ Parameters:
       - production
     Type: String
   pInstanceClass:
-    Description: The DocumentDB instance class
+    Description: The DocumentDB instance class, only used when pDbMode is provisioned
     Type: String
     Default: db.t4g.medium
   pInstanceCount:
@@ -50,6 +59,18 @@ Parameters:
   pProductName:
     Description: The product name
     Type: String
+  pServerlessMaxCapacity:
+    Description: The maximum capacity in DCUs, only used when pDbMode is serverless
+    Type: Number
+    MinValue: 1
+    MaxValue: 256
+    Default: 2
+  pServerlessMinCapacity:
+    Description: The minimum capacity in DCUs, only used when pDbMode is serverless
+    Type: Number
+    MinValue: 0.5
+    MaxValue: 256
+    Default: 0.5
   pVpcStackName:
     Description: The name of the Bedrock VPC stack
     Type: String
@@ -61,6 +82,12 @@ Conditions:
   IsProd: !Equals
     - !Ref pEnvironment
     - production
+  IsProvisioned: !Equals
+    - !Ref pDbMode
+    - provisioned
+  IsServerless: !Equals
+    - !Ref pDbMode
+    - serverless
 
 Resources:
 
@@ -134,6 +161,11 @@ Resources:
         - ResourceName: !If [ IsDev, !Ref pCleanBranch, !Ref pEnvironment ]
       PreferredBackupWindow: 16:00-17:00
       PreferredMaintenanceWindow: tue:17:00-tue:19:00
+      ServerlessV2ScalingConfiguration: !If
+        - IsServerless
+        - MinCapacity: !Ref pServerlessMinCapacity
+          MaxCapacity: !Ref pServerlessMaxCapacity
+        - !Ref AWS::NoValue
       StorageEncrypted: true
       Tags:
         - Key: Name
@@ -145,6 +177,7 @@ Resources:
 
   DocDbInstance:
     Type: AWS::DocDB::DBInstance
+    Condition: IsProvisioned
     Properties:
       DBClusterIdentifier: !Ref DocDbCluster
       DBInstanceClass: !Ref pInstanceClass
@@ -156,7 +189,27 @@ Resources:
             - ${pProductName}-${ResourceName}-instance
             - ResourceName: !If [ IsDev, !Ref pCleanBranch, !Ref pEnvironment ]
 
+  DocDbServerlessInstance:
+    Type: AWS::DocDB::DBInstance
+    Condition: IsServerless
+    Properties:
+      DBClusterIdentifier: !Ref DocDbCluster
+      DBInstanceClass: db.serverless
+      AutoMinorVersionUpgrade: true
+      EnablePerformanceInsights: !Ref pEnablePerformanceInsights
+      Tags:
+        - Key: Name
+          Value: !Sub
+            - ${pProductName}-${ResourceName}-instance
+            - ResourceName: !If [ IsDev, !Ref pCleanBranch, !Ref pEnvironment ]
+
 Outputs:
+
+  DocDbMode:
+    Description: The capacity mode of the DocumentDB cluster
+    Value: !Ref pDbMode
+    Export:
+      Name: !Sub ${AWS::StackName}-DocDbMode
 
   DocDbUsername:
     Description: The DocumentDB username

--- a/cicd/database/app/database_template_config.j2
+++ b/cicd/database/app/database_template_config.j2
@@ -5,12 +5,15 @@
     "pBuild"                    : "{{ codebuild_build_number }}",
     "pCleanBranch"              : "{{ clean_branch }}",
     "pDbEngineVersion"          : "{{ db_engine_version }}",
+    "pDbMode"                   : "{{ db_mode }}",
     "pDbParameterGroupFamily"   : "{{ db_parameter_group_family }}",
     "pEnablePerformanceInsights": "{{ enable_performance_insights }}",
     "pEnvironment"              : "{{ environment }}",
     "pInstanceClass"            : "{{ instance_class }}",
     "pInstanceCount"            : "{{ instance_count }}",
     "pProductName"              : "{{ product_name }}",
+    "pServerlessMaxCapacity"    : "{{ serverless_max_capacity }}",
+    "pServerlessMinCapacity"    : "{{ serverless_min_capacity }}",
     "pVpcStackName"             : "{{ vpc_stack_name }}"
   },
   "Tags" : {

--- a/cicd/database/config.ini
+++ b/cicd/database/config.ini
@@ -11,16 +11,21 @@ SLACK_ALERT_CHANNEL = testing-deployments
 ADMIN_USER = adminuser
 BACKUP_RETENTION_PERIOD = 7
 DB_INSTANCE_NAME = lists-${ENVIRONMENT}
+DB_MODE = provisioned
 DB_PARAMETER_GROUP_FAMILY = docdb8.0
 DB_ENGINE_VERSION = 8.0
 INSTANCE_CLASS = db.t4g.medium
 INSTANCE_COUNT = 1
 ENABLE_PERFORMANCE_INSIGHTS = false
+# only used when DB_MODE = serverless, capacity is measured in DCUs
+SERVERLESS_MIN_CAPACITY = 0.5
+SERVERLESS_MAX_CAPACITY = 2
 
 
 [development]
 # code pipeline
 PIPELINE_STACK_NAME = ala-${PRODUCT_NAME}-${PRODUCT_COMPONENT}-pipeline-${CLEAN_BRANCH}
+DB_MODE = serverless
 
 # DocDB
 BACKUP_RETENTION_PERIOD = 2

--- a/cicd/database/config.ini
+++ b/cicd/database/config.ini
@@ -35,6 +35,7 @@ ENABLE_PERFORMANCE_INSIGHTS = true
 [testing]
 # DocDB
 ENABLE_PERFORMANCE_INSIGHTS = true
+DB_MODE = serverless
 
 [staging]
 # DocDB


### PR DESCRIPTION
Added a new database option in config.ini to toggle between provisioned and serverless mode for the DocumentDB database
```
DB_MODE = provisioned
```
also values for maximum and minimum autoscaling capacity
```
# only used when DB_MODE = serverless, capacity is measured in DCUs
SERVERLESS_MIN_CAPACITY = 0.5
SERVERLESS_MAX_CAPACITY = 2
``` 
Serverless is cheaper and less emissions for quiet loads and development / test environments where usage is not around the clock 24/7. I tested the migration on a branch and it was nicer than some of the other AWS serverless options, it handled switching back and forth itself with a managed failover without data loss, I dont think there would have been much if any interruption to service as well.

This branch enables it for development and testing environments, it may even work for us in production as it autoscales to demand

https://aws.amazon.com/documentdb/serverless/