### PR TITLE
enforce TLS access for buckets

### DIFF
--- a/cicd/base/app/base.yaml
+++ b/cicd/base/app/base.yaml
@@ -1,58 +1,72 @@
-AWSTemplateFormatVersion: '2010-09-09'
+AWSTemplateFormatVersion: "2010-09-09"
 
 Description: Base resources for the Lists service
 
 Parameters:
   pBuild:
-    Type: String
     Description: The build number
+    Type: String
+
   pCleanBranch:
-    Type: String
     Description: The clean branch, can be used in resource names
+    Type: String
+
   pEnvironment:
-    Type: String
     Description: The AWS environment this belongs to
+    Type: String
+
   pProductName:
-    Type: String
     Description: The product name, used in resource names
+    Type: String
+
   pCognitoStackName:
-    Type: String
     Description: The name of the Cognito stack
+    Type: String
+
   pAppClientHost:
-    Type: String
     Description: The host for the app client for the frontend
+    Type: String
+
   pAppClientServiceHost:
-    Type: String
     Description: The host for the app client for the service
+    Type: String
+
   pOidcConnectProvider:
-    Type: String
     Description: The OIDC connect provider
+    Type: String
+
   pClusterOidcIssuerUrl:
-    Type: String
     Description: The OIDC issuer URL for the cluster
-  pEksNamespace:
     Type: String
+
+  pEksNamespace:
     Description: The EKS namespace for the service account
+    Type: String
 
 Conditions:
-
   IsDev: !Equals
     - !Ref pEnvironment
     - development
+
   NotProd: !Not
     - !Equals
       - !Ref pEnvironment
       - production
-  IsFirstBuild: !Equals [!Ref pBuild, "1"]
+
+  IsFirstBuild: !Equals
+    - !Ref pBuild
+    - "1"
 
 Resources:
-
   DocDbPasswordSecret:
     Type: AWS::SecretsManager::Secret
     Properties:
-      Name: !Sub 
-              - lists-${ResourceName}
-              - ResourceName: !If [ IsDev, !Ref pCleanBranch, !Ref pEnvironment ]
+      Name: !Sub
+        - lists-${ResourceName}
+        - ResourceName: !If
+            - IsDev
+            - !Ref pCleanBranch
+            - !Ref pEnvironment
       Description: !Sub Lists app ${pEnvironment} secrets
       GenerateSecretString:
         SecretStringTemplate: |
@@ -63,21 +77,24 @@ Resources:
           }
         GenerateStringKey: db-password
         PasswordLength: 12
-        ExcludeCharacters: "/@\"\\#<>: "
+        ExcludeCharacters: '/@"\#<>: '
       Tags:
         - Key: Name
           Value: !Sub
             - ${pProductName}-${ResourceName}
-            - ResourceName: !If [ IsDev, !Ref pCleanBranch, !Ref pEnvironment ]
+            - ResourceName: !If
+                - IsDev
+                - !Ref pCleanBranch
+                - !Ref pEnvironment
 
   ListsAppClient:
     Type: AWS::Cognito::UserPoolClient
     Properties:
       AccessTokenValidity: 8
-      AllowedOAuthFlows: 
+      AllowedOAuthFlows:
         - code
       AllowedOAuthFlowsUserPoolClient: True
-      AllowedOAuthScopes: 
+      AllowedOAuthScopes:
         - ala/attrs
         - ala/internal
         - ala/roles
@@ -86,14 +103,17 @@ Resources:
         - profile
         - users/read
       AuthSessionValidity: 3
-      CallbackURLs: 
+      CallbackURLs:
         - !Sub ${pAppClientHost}
         - !Sub ${pAppClientHost}/
         - !Sub ${pAppClientHost}/callback?client_name=OidcClient
         - !Sub ${pAppClientHost}/oauth2-redirect.html
       ClientName: !Sub
-          - species-lists-ui-${ResourceName}
-          - ResourceName: !If [ IsDev, !Ref pCleanBranch, !Ref pEnvironment ]
+        - species-lists-ui-${ResourceName}
+        - ResourceName: !If
+            - IsDev
+            - !Ref pCleanBranch
+            - !Ref pEnvironment
       DefaultRedirectURI: !Sub ${pAppClientHost}
       EnablePropagateAdditionalUserContextData: False
       EnableTokenRevocation: True
@@ -104,7 +124,7 @@ Resources:
         - ALLOW_USER_SRP_AUTH
       GenerateSecret: False
       IdTokenValidity: 8
-      LogoutURLs: 
+      LogoutURLs:
         - !Sub ${pAppClientHost}
         - !Sub ${pAppClientHost}/
       PreventUserExistenceErrors: ENABLED
@@ -119,31 +139,33 @@ Resources:
         AccessToken: hours
         IdToken: hours
         RefreshToken: days
-      UserPoolId: 
-        Fn::ImportValue:
-            !Sub ${pCognitoStackName}-UserPoolId
+      UserPoolId: !ImportValue
+        Fn::Sub: ${pCognitoStackName}-UserPoolId
 
   ListsServiceAppClient:
     Type: AWS::Cognito::UserPoolClient
     Properties:
       AccessTokenValidity: 8
-      AllowedOAuthFlows: 
+      AllowedOAuthFlows:
         - client_credentials
       AllowedOAuthFlowsUserPoolClient: True
-      AllowedOAuthScopes: 
+      AllowedOAuthScopes:
         - ala/attrs
         - ala/roles
         - ala/internal
         - users/read
       AuthSessionValidity: 3
-      CallbackURLs: 
+      CallbackURLs:
         - !Sub ${pAppClientServiceHost}
         - !Sub ${pAppClientServiceHost}/
         - !Sub ${pAppClientServiceHost}/callback?client_name=OidcClient
         - !Sub ${pAppClientServiceHost}/oauth2-redirect.html
       ClientName: !Sub
-          - species-lists-s2s-${ResourceName}
-          - ResourceName: !If [ IsDev, !Ref pCleanBranch, !Ref pEnvironment ]
+        - species-lists-s2s-${ResourceName}
+        - ResourceName: !If
+            - IsDev
+            - !Ref pCleanBranch
+            - !Ref pEnvironment
       DefaultRedirectURI: !Sub ${pAppClientServiceHost}/callback?client_name=OidcClient
       EnablePropagateAdditionalUserContextData: True
       EnableTokenRevocation: True
@@ -154,7 +176,7 @@ Resources:
         - ALLOW_USER_SRP_AUTH
       GenerateSecret: True
       IdTokenValidity: 8
-      LogoutURLs: 
+      LogoutURLs:
         - !Sub ${pAppClientServiceHost}
         - !Sub ${pAppClientServiceHost}/
       PreventUserExistenceErrors: ENABLED
@@ -169,16 +191,18 @@ Resources:
         AccessToken: hours
         IdToken: hours
         RefreshToken: days
-      UserPoolId: 
-        Fn::ImportValue:
-            !Sub ${pCognitoStackName}-UserPoolId
+      UserPoolId: !ImportValue
+        Fn::Sub: ${pCognitoStackName}-UserPoolId
 
   LoadBalancerAccessLogsBucket:
     Type: AWS::S3::Bucket
     Properties:
       BucketName: !Sub
         - ala-${pProductName}-${ResourceName}-alb-access-logs
-        - ResourceName: !If [ IsDev, !Ref pCleanBranch, !Ref pEnvironment ]
+        - ResourceName: !If
+            - IsDev
+            - !Ref pCleanBranch
+            - !Ref pEnvironment
       PublicAccessBlockConfiguration:
         BlockPublicAcls: true
         BlockPublicPolicy: true
@@ -186,10 +210,10 @@ Resources:
         RestrictPublicBuckets: true
       LifecycleConfiguration:
         Rules:
-          - Id: "ExpireOldLogs"
+          - Id: ExpireOldLogs
             Status: Enabled
             ExpirationInDays: 90
-            Prefix: "logs/"
+            Prefix: logs/
       OwnershipControls:
         Rules:
           - ObjectOwnership: ObjectWriter
@@ -207,9 +231,9 @@ Resources:
           - Sid: AllowELBAccess
             Effect: Allow
             Principal:
-              Service: "logdelivery.elasticloadbalancing.amazonaws.com"
-            Action: "s3:PutObject"
-            Resource: !Sub "arn:aws:s3:::${LoadBalancerAccessLogsBucket}/logs/AWSLogs/${AWS::AccountId}/*"
+              Service: logdelivery.elasticloadbalancing.amazonaws.com
+            Action: s3:PutObject
+            Resource: !Sub arn:aws:s3:::${LoadBalancerAccessLogsBucket}/logs/AWSLogs/${AWS::AccountId}/*
           - Sid: TLSAccessOnly
             Action:
               - s3:*
@@ -220,7 +244,7 @@ Resources:
             Principal: '*'
             Condition:
               Bool:
-                'aws:SecureTransport': "false"
+                aws:SecureTransport: "false"
 
   ListsRole:
     Type: AWS::IAM::Role
@@ -246,13 +270,13 @@ Resources:
                 "Effect": "Allow",
                 "Principal": {
                   "Service":  "ec2.amazonaws.com"
-        
+
                 },
                 "Action": "sts:AssumeRole"
               }
           ]
         }
-      Description: !Sub 'IAM role for lists uploads bucket access ${AWS::StackName} ${pEnvironment} build ${pBuild}'
+      Description: !Sub IAM role for lists uploads bucket access ${AWS::StackName} ${pEnvironment} build ${pBuild}
       ManagedPolicyArns:
         - !Sub arn:aws:iam::${AWS::AccountId}:policy/cpt/cptSSMInstanceCoreCloudWatchPatch
       Policies:
@@ -273,25 +297,34 @@ Resources:
           PolicyName: lists-uploads-bucket
       RoleName: !Sub
         - ${pProductName}-${ResourceName}
-        - ResourceName: !If [ IsDev, !Ref pCleanBranch, !Ref pEnvironment ]
+        - ResourceName: !If
+            - IsDev
+            - !Ref pCleanBranch
+            - !Ref pEnvironment
       Tags:
         - Key: Name
           Value: !Sub
             - ${pProductName}-${ResourceName}
-            - ResourceName: !If [ IsDev, !Ref pCleanBranch, !Ref pEnvironment ]
+            - ResourceName: !If
+                - IsDev
+                - !Ref pCleanBranch
+                - !Ref pEnvironment
 
   ListsInstanceProfile:
     Type: AWS::IAM::InstanceProfile
     Properties:
       InstanceProfileName: !Sub
         - ${pProductName}-${ResourceName}
-        - ResourceName: !If [ IsDev, !Ref pCleanBranch, !Ref pEnvironment ]
+        - ResourceName: !If
+            - IsDev
+            - !Ref pCleanBranch
+            - !Ref pEnvironment
       Roles:
         - !Ref ListsRole
 
   ListsUploadsBucket:
-    Type: AWS::S3::Bucket
     DeletionPolicy: Delete
+    Type: AWS::S3::Bucket
     Properties:
       BucketEncryption:
         ServerSideEncryptionConfiguration:
@@ -299,7 +332,10 @@ Resources:
               SSEAlgorithm: AES256
       BucketName: !Sub
         - ala-${pProductName}-${ResourceName}
-        - ResourceName: !If [ IsDev, !Ref pCleanBranch, !Ref pEnvironment ]
+        - ResourceName: !If
+            - IsDev
+            - !Ref pCleanBranch
+            - !Ref pEnvironment
       LifecycleConfiguration:
         Rules:
           - Id: delete
@@ -318,10 +354,31 @@ Resources:
         - Key: Name
           Value: !Sub
             - ala-${pProductName}-${ResourceName}
-            - ResourceName: !If [ IsDev, !Ref pCleanBranch, !Ref pEnvironment ]
+            - ResourceName: !If
+                - IsDev
+                - !Ref pCleanBranch
+                - !Ref pEnvironment
+
+  ListsUploadsBucketPolicy:
+    Type: AWS::S3::BucketPolicy
+    Properties:
+      Bucket: !Ref ListsUploadsBucket
+      PolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Sid: TLSAccessOnly
+            Action:
+              - s3:*
+            Effect: Deny
+            Resource:
+              - !Sub arn:aws:s3:::${ListsUploadsBucket}
+              - !Sub arn:aws:s3:::${ListsUploadsBucket}/*
+            Principal: '*'
+            Condition:
+              Bool:
+                aws:SecureTransport: "false"
 
 Outputs:
-
   AppClientId:
     Description: The app client for the lists frontend
     Value: !Ref ListsAppClient
@@ -329,10 +386,13 @@ Outputs:
       Name: !Sub ${AWS::StackName}-AppClientId
 
   DocDbPasswordSecretName:
-    Description: The Secrets name for lists 
+    Description: The Secrets name for lists
     Value: !Sub
       - lists-${ResourceName}
-      - ResourceName: !If [ IsDev, !Ref pCleanBranch, !Ref pEnvironment ]
+      - ResourceName: !If
+          - IsDev
+          - !Ref pCleanBranch
+          - !Ref pEnvironment
     Export:
       Name: !Sub ${AWS::StackName}-DocDbPasswordSecretName
 

--- a/cicd/frontend/app/lists.yaml
+++ b/cicd/frontend/app/lists.yaml
@@ -1,46 +1,57 @@
-AWSTemplateFormatVersion: '2010-09-09'
+AWSTemplateFormatVersion: "2010-09-09"
+
 Description: LISTS Infrastructure
 
 Parameters:
   pListsWafWebAclArn:
-    Type: String
     Description: The WAF Web ACL to attach the CloudFront distribution to
+    Type: String
+
   pSourceBucket:
-    Type: String
     Description: The bucket name for the site
+    Type: String
+
   pBucketPath:
-    Type: String
     Description: Optional path that the files are stored under
+    Type: String
+
   pCleanBranch:
-    Type: String
     Description: A cleaned version of the code branch name
+    Type: String
     Default: development
+
   pEnvironment:
-    Type: String
     Description: The AWS environment this belongs to
+    Type: String
+
   pHostedZone:
-    Type: String
     Description: The hosted zone the site are accessed under
+    Type: String
+
   pUiSubDomain:
-    Type: String
     Description: The subdomain the site are accessed on
+    Type: String
+
   pWsSubDomain:
-    Type: String
     Description: The subdomain the backend API is accessed on
-  pCloudfrontCertificate:
     Type: String
+
+  pCloudfrontCertificate:
     Description: The arn of the SSL certificate to be used
+    Type: String
 
 Conditions:
   IsDev: !Equals
     - !Ref pEnvironment
     - development
-  NotDev: !Not [ Condition: IsDev ]
+
+  NotDev: !Not
+    - !Condition IsDev
 
 Resources:
   ListsBucket:
-    Type: 'AWS::S3::Bucket'
     DeletionPolicy: Delete
+    Type: AWS::S3::Bucket
     Properties:
       BucketName: !Sub ${pSourceBucket}
       PublicAccessBlockConfiguration:
@@ -58,26 +69,41 @@ Resources:
     Properties:
       Bucket: !Ref ListsBucket
       PolicyDocument:
-        Version: 2012-10-17
+        Version: "2012-10-17"
         Statement:
-          - Action:
-              - 's3:GetObject'
+          - Sid: CloudFrontAccess
+            Action:
+              - s3:GetObject
             Effect: Allow
-            Resource: !Sub 'arn:aws:s3:::${ListsBucket}/*'
+            Resource: !Sub arn:aws:s3:::${ListsBucket}/*
             Principal:
-              AWS: !Sub 'arn:aws:iam::cloudfront:user/CloudFront Origin Access Identity ${ListsCloudFrontOai}'
+              AWS: !Sub arn:aws:iam::cloudfront:user/CloudFront Origin Access Identity ${ListsCloudFrontOai}
+          - Sid: TLSAccessOnly
+            Action:
+              - s3:*
+            Effect: Deny
+            Resource:
+              - !Sub arn:aws:s3:::${ListsBucket}
+              - !Sub arn:aws:s3:::${ListsBucket}/*
+            Principal: '*'
+            Condition:
+              Bool:
+                aws:SecureTransport: "false"
 
   WsRedirectFunction:
     Type: AWS::CloudFront::Function
     Properties:
-      Name: !Sub 
-        - "lists-ws-redirect-${ResourceName}"
-        - ResourceName: !If [ IsDev, !Ref pCleanBranch, !Ref pEnvironment ]
+      Name: !Sub
+        - lists-ws-redirect-${ResourceName}
+        - ResourceName: !If
+            - IsDev
+            - !Ref pCleanBranch
+            - !Ref pEnvironment
       AutoPublish: true
       FunctionConfig:
         Comment: Redirect /ws/* to the backend domain
         Runtime: cloudfront-js-1.0
-      FunctionCode: !Sub 
+      FunctionCode: !Sub
         - |
           function handler(event) {
               var request = event.request;
@@ -108,18 +134,18 @@ Resources:
                   }
               };
           }
-        - Domain: !Sub "${pWsSubDomain}.${pHostedZone}"
+        - Domain: !Sub ${pWsSubDomain}.${pHostedZone}
 
   ListsDnsRecord:
     Type: AWS::Route53::RecordSet
     Properties:
-      Name: !Sub '${pUiSubDomain}.${pHostedZone}'
+      Name: !Sub ${pUiSubDomain}.${pHostedZone}
       Comment: !Sub LISTS domain for the ${pEnvironment} environment
       Type: A
       AliasTarget:
         DNSName: !GetAtt ListsCloudFrontDistro.DomainName
         HostedZoneId: Z2FDTNDATAQYW2
-      HostedZoneName: !Sub '${pHostedZone}.'
+      HostedZoneName: !Sub ${pHostedZone}.
 
   ListsCloudFrontDistro:
     Type: AWS::CloudFront::Distribution
@@ -127,7 +153,7 @@ Resources:
     Properties:
       DistributionConfig:
         Aliases:
-          - !Sub '${pUiSubDomain}.${pHostedZone}'
+          - !Sub ${pUiSubDomain}.${pHostedZone}
         Comment: !Sub CF Distribution for the LISTS site ${pEnvironment}
         CustomErrorResponses:
           - ErrorCode: 403
@@ -135,7 +161,7 @@ Resources:
             ResponseCode: 200
             ResponsePagePath: /index.html
         CacheBehaviors:
-          - PathPattern: '/ws/*'
+          - PathPattern: /ws/*
             TargetOriginId: lists-s3
             ViewerProtocolPolicy: redirect-to-https
             AllowedMethods:
@@ -144,6 +170,7 @@ Resources:
             CachedMethods:
               - GET
               - HEAD
+
             # AWS Managed CachingDisabled Policy
             CachePolicyId: 4135ea2d-6df8-44a3-9df3-4b5a84be39ad
             FunctionAssociations:
@@ -165,11 +192,11 @@ Resources:
         HttpVersion: http2
         IPV6Enabled: false
         Origins:
-          - DomainName: !Sub '${pSourceBucket}.s3.${AWS::Region}.amazonaws.com'
+          - DomainName: !Sub ${pSourceBucket}.s3.${AWS::Region}.amazonaws.com
             Id: lists-s3
             S3OriginConfig:
-              OriginAccessIdentity: !Sub 'origin-access-identity/cloudfront/${ListsCloudFrontOai}'
-            OriginPath: !Sub '/${pBucketPath}'
+              OriginAccessIdentity: !Sub origin-access-identity/cloudfront/${ListsCloudFrontOai}
+            OriginPath: !Sub /${pBucketPath}
         ViewerCertificate:
           AcmCertificateArn: !Ref pCloudfrontCertificate
           MinimumProtocolVersion: TLSv1.2_2021
@@ -188,8 +215,11 @@ Resources:
         MaxTTL: 86400
         MinTTL: 1
         Name: !Sub
-          - "Lists-cache-Policy-${ResourceName}"
-          - ResourceName: !If [ IsDev, !Ref pCleanBranch, !Ref pEnvironment ]
+          - Lists-cache-Policy-${ResourceName}
+          - ResourceName: !If
+              - IsDev
+              - !Ref pCleanBranch
+              - !Ref pEnvironment
         ParametersInCacheKeyAndForwardedToOrigin:
           CookiesConfig:
             CookieBehavior: none
@@ -211,9 +241,11 @@ Resources:
 Outputs:
   ListsBucketName:
     Value: !Ref ListsBucket
+
   ListsBucketArn:
     Value: !GetAtt ListsBucket.Arn
+
   ListsCloudFrontDistributionArn:
     Value: !Sub
-      - "arn:aws:cloudfront::${AWS::AccountId}:distribution/${DistributionId}"
+      - arn:aws:cloudfront::${AWS::AccountId}:distribution/${DistributionId}
       - DistributionId: !GetAtt ListsCloudFrontDistro.Id


### PR DESCRIPTION
All this does is require TLS access to all buckets. IM&T keeps sending remediation messages about it. There are a ton of formatting / linting changes as this must be the first time these templates have passed through the pre-commit hooks 