### PR TITLE
Restore lists-service compatibility with Spring Boot 4.1

### DIFF
--- a/lists-service/pom.xml
+++ b/lists-service/pom.xml
@@ -38,6 +38,11 @@
 
   <dependencies>
     <dependency>
+      <groupId>org.apache.httpcomponents</groupId>
+      <artifactId>httpcore</artifactId>
+      <version>4.4.16</version>
+    </dependency>
+    <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-actuator</artifactId>
     </dependency>

--- a/lists-service/src/main/java/au/org/ala/listsapi/ListsApiApplication.java
+++ b/lists-service/src/main/java/au/org/ala/listsapi/ListsApiApplication.java
@@ -5,7 +5,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.boot.ApplicationArguments;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.boot.web.embedded.tomcat.TomcatServletWebServerFactory;
+import org.springframework.boot.tomcat.servlet.TomcatServletWebServerFactory;
 import org.springframework.boot.web.server.WebServerFactoryCustomizer;
 import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.context.MessageSource;

--- a/lists-service/src/main/java/au/org/ala/listsapi/service/SearchHelperService.java
+++ b/lists-service/src/main/java/au/org/ala/listsapi/service/SearchHelperService.java
@@ -583,7 +583,9 @@ public class SearchHelperService {
                     .size(MAX_LIST_ENTRIES)
                 )
                 .aggregations("max_score",
-                    Aggregation.of(ma -> ma.max(m -> m.script(s -> s.source("_score"))))
+                    Aggregation.of(ma -> ma.max(m -> m.script(s -> s.source(
+                        source -> source.scriptString("_score")
+                    ))))
                 )
             )
         );

--- a/lists-service/src/main/java/au/org/ala/listsapi/service/SpeciesListSearchService.java
+++ b/lists-service/src/main/java/au/org/ala/listsapi/service/SpeciesListSearchService.java
@@ -215,7 +215,9 @@ public class SpeciesListSearchService {
                     .size(MAX_LIST_ENTRIES)
                 )
                 .aggregations("max_score",
-                    Aggregation.of(ma -> ma.max(m -> m.script(s -> s.source("_score"))))
+                    Aggregation.of(ma -> ma.max(m -> m.script(s -> s.source(
+                        source -> source.scriptString("_score")
+                    ))))
                 )
             )
         );


### PR DESCRIPTION
Companion fix for #761.

The Spring Boot 4.1 update exposed three compatibility breaks in `lists-service`:
- Apache HttpComponents 4 types used by the service were no longer present transitively;
- the embedded Tomcat factory moved packages;
- Elasticsearch 9.4 changed the script source builder API.

This adds the required HttpCore 4 module and updates only those moved APIs.

Verification on JDK 21:
- `mvn -B test`
- 96 tests passed with no failures or errors;
- the dependency tree resolves `org.apache.httpcomponents:httpcore:4.4.16`.